### PR TITLE
Call _nodeRegistration() before setup()

### DIFF
--- a/core/MySensorsCore.cpp
+++ b/core/MySensorsCore.cpp
@@ -145,16 +145,17 @@ void _begin() {
 		}
 	#endif	
 	
-	// Call sketch setup
-	if (setup)
-		setup();
-
 	#if defined(MY_RADIO_FEATURE)
 		presentNode();
 	#endif
 	
 	// register node
 	_registerNode();
+
+	// Call sketch setup
+	if (setup) {
+		setup();
+	}
 
 	debug(PSTR("Init complete, id=%d, parent=%d, distance=%d, registration=%d\n"), _nc.nodeId, _nc.parentNodeId, _nc.distance, _nodeRegistered);
 }


### PR DESCRIPTION
Node needs to be registered before it can send sensor-related data (this excludes internal messages and routing). Calling _nodeRegistration() before setup() allows sending data in sketch setup().

- fixes #514 
