### PR TITLE
Calling WiFi.config() before WiFi.begin()

### DIFF
--- a/core/MyGatewayTransportEthernet.cpp
+++ b/core/MyGatewayTransportEthernet.cpp
@@ -106,10 +106,10 @@ bool gatewayTransportInit() {
 			#if defined(MY_ESP8266_HOSTNAME)
 				WiFi.hostname(MY_ESP8266_HOSTNAME);
 			#endif
-			(void)WiFi.begin(MY_ESP8266_SSID, MY_ESP8266_PASSWORD);
 			#ifdef MY_IP_ADDRESS
 				WiFi.config(_ethernetGatewayIP, _gatewayIp, _subnetIp);
 			#endif
+			(void)WiFi.begin(MY_ESP8266_SSID, MY_ESP8266_PASSWORD);
 			while (WiFi.status() != WL_CONNECTED)
 			{
 				delay(500);


### PR DESCRIPTION
Calling WiFi.config() before WiFi.begin() forces begin() to configure the WiFi shield with the network addresses specified in config().

- Fixes #516 