### PR TITLE
Fix smartsleep

### DIFF
--- a/core/MySensorsCore.cpp
+++ b/core/MySensorsCore.cpp
@@ -463,7 +463,7 @@ int8_t sleep(unsigned long ms) {
 }
 
 int8_t smartSleep(unsigned long ms) {
-	// notifiy controller about going to sleep
+	// notify controller about going to sleep
 	sendHeartbeat();
 	// listen for incoming messages
 	wait(MY_SMART_SLEEP_WAIT_DURATION);
@@ -495,7 +495,7 @@ int8_t sleep(uint8_t interrupt, uint8_t mode, unsigned long ms) {
 }
 
 int8_t smartSleep(uint8_t interrupt, uint8_t mode, unsigned long ms) {
-	// notifiy controller about going to sleep
+	// notify controller about going to sleep
 	sendHeartbeat();
 	// listen for incoming messages
 	wait(MY_SMART_SLEEP_WAIT_DURATION);
@@ -529,7 +529,7 @@ int8_t sleep(uint8_t interrupt1, uint8_t mode1, uint8_t interrupt2, uint8_t mode
 }
 
 int8_t smartSleep(uint8_t interrupt1, uint8_t mode1, uint8_t interrupt2, uint8_t mode2, unsigned long ms) {
-	// notifiy controller about going to sleep
+	// notify controller about going to sleep
 	sendHeartbeat();
 	// listen for incoming messages
 	wait(MY_SMART_SLEEP_WAIT_DURATION);

--- a/core/MySensorsCore.cpp
+++ b/core/MySensorsCore.cpp
@@ -65,7 +65,7 @@ void _infiniteLoop() {
 }
 
 void _begin() {
-		
+
 	#if !defined(MY_DISABLED_SERIAL)
 	    hwInit();
 	#endif
@@ -73,7 +73,7 @@ void _begin() {
 	debug(PSTR("MCO:BGN:INIT " MY_NODE_TYPE ",CP=" MY_CAPABILITIES ",VER=" MYSENSORS_LIBRARY_VERSION "\n"));
 
 	// Call before() in sketch (if it exists)
-	if (before) 
+	if (before)
 		before();
 
 	#if defined(MY_LEDS_BLINKING_FEATURE)
@@ -85,7 +85,7 @@ void _begin() {
 	// Read latest received controller configuration from EEPROM
 	// Note: _cc.isMetric is bool, hence empty EEPROM (=0xFF) evaluates to true (default)
 	hwReadConfigBlock((void*)&_cc, (void*)EEPROM_CONTROLLER_CONFIG_ADDRESS, sizeof(ControllerConfig));
-	
+
 	#if defined(MY_OTA_FIRMWARE_FEATURE)
 		// Read firmware config from EEPROM, i.e. type, version, CRC, blocks
 		readFirmwareSettings();
@@ -104,7 +104,7 @@ void _begin() {
 		}
 	#endif
 
-	
+
 
 	#ifdef MY_NODE_LOCK_FEATURE
 		// Check if node has been locked down
@@ -131,7 +131,7 @@ void _begin() {
 			hwWriteConfig(EEPROM_NODE_LOCK_COUNTER, MY_NODE_LOCK_COUNTER_MAX);
 		}
 	#endif
-	
+
 	#if defined(MY_GATEWAY_FEATURE)
 		#if defined(MY_INCLUSION_BUTTON_FEATURE)
 	    	inclusionInit();
@@ -144,12 +144,12 @@ void _begin() {
 			// Nothing more we can do
 			_infiniteLoop();
 		}
-	#endif	
-	
+	#endif
+
 	#if !defined(MY_GATEWAY_FEATURE)
 		presentNode();
 	#endif
-	
+
 	// register node
 	_registerNode();
 
@@ -173,7 +173,7 @@ void _registerNode() {
 			_sendRoute(build(_msgTmp, _nc.nodeId, GATEWAY_ADDRESS, NODE_SENSOR_ID, C_INTERNAL, I_REGISTRATION_REQUEST, false).set(MY_CORE_VERSION));
 		} while (!wait(2000, C_INTERNAL, I_REGISTRATION_RESPONSE) && counter--);
 
-	#else 
+	#else
 		_nodeRegistered = true;
 		debug(PSTR("MCO:REG:NOT NEEDED\n"));
 	#endif
@@ -190,11 +190,11 @@ void presentNode() {
 			present(NODE_SENSOR_ID, S_ARDUINO_NODE);
 		#endif
 	#else
-		
+
 		#if defined(MY_OTA_FIRMWARE_FEATURE)
 				presentBootloaderInformation();
 		#endif
-		
+
 		// Send signing preferences for this node to the GW
 		signerPresentation(_msgTmp, GATEWAY_ADDRESS);
 
@@ -204,16 +204,16 @@ void presentNode() {
 		#else
 				present(NODE_SENSOR_ID, S_ARDUINO_NODE);
 		#endif
-		
+
 		// Send a configuration exchange request to controller
 		// Node sends parent node. Controller answers with latest node configuration
 		_sendRoute(build(_msgTmp, _nc.nodeId, GATEWAY_ADDRESS, NODE_SENSOR_ID, C_INTERNAL, I_CONFIG, false).set(_nc.parentNodeId));
 
 		// Wait configuration reply.
 		wait(2000, C_INTERNAL, I_CONFIG);
-	
+
 	#endif
-	
+
 	if (presentation)
 		presentation();
 
@@ -257,7 +257,7 @@ bool send(MyMessage &message, bool enableAck) {
 	mSetRequestAck(message, enableAck);
 
 	#if defined(MY_REGISTRATION_FEATURE) && !defined(MY_GATEWAY_FEATURE)
-		if (_nodeRegistered) {	
+		if (_nodeRegistered) {
 			return _sendRoute(message);
 		}
 		else {
@@ -379,17 +379,17 @@ bool _processInternalMessages() {
 			#endif
 		}
 		else return false;
-	} 
+	}
 	else {
 		// sender is a node
 		if (type == I_REGISTRATION_REQUEST) {
 			#if defined(MY_GATEWAY_FEATURE)
 				// register request are exclusively handled by GW/Controller
 				// !!! eventually define if AUTO ACK or register request forwarded to controller
-				#if !defined(MY_REGISTRATION_CONTROLLER) 
+				#if !defined(MY_REGISTRATION_CONTROLLER)
 					// auto register if version compatible
 					bool approveRegistration = true;
-					
+
 					#if defined(MY_CORE_COMPATIBILITY_CHECK)
 							approveRegistration = (_msg.getByte() >= MY_CORE_MIN_VERSION);
 					#endif
@@ -397,7 +397,7 @@ bool _processInternalMessages() {
 				#else
 					return false;	// processing of this request via controller
 				#endif
-			#endif	
+			#endif
 		}
 		else return false;
 	}
@@ -463,12 +463,11 @@ int8_t sleep(unsigned long ms) {
 }
 
 int8_t smartSleep(unsigned long ms) {
-	int8_t ret = sleep(ms);
-	// notifiy controller about wake up
+	// notifiy controller about going to sleep
 	sendHeartbeat();
 	// listen for incoming messages
 	wait(MY_SMART_SLEEP_WAIT_DURATION);
-	return ret;
+	return sleep(ms);
 }
 
 int8_t sleep(uint8_t interrupt, uint8_t mode, unsigned long ms) {
@@ -496,12 +495,11 @@ int8_t sleep(uint8_t interrupt, uint8_t mode, unsigned long ms) {
 }
 
 int8_t smartSleep(uint8_t interrupt, uint8_t mode, unsigned long ms) {
-	int8_t ret = sleep(interrupt, mode, ms);
-	// notifiy controller about wake up
+	// notifiy controller about going to sleep
 	sendHeartbeat();
 	// listen for incoming messages
 	wait(MY_SMART_SLEEP_WAIT_DURATION);
-	return ret;
+	return sleep(interrupt, mode, ms);
 }
 
 int8_t sleep(uint8_t interrupt1, uint8_t mode1, uint8_t interrupt2, uint8_t mode2, unsigned long ms) {
@@ -531,12 +529,11 @@ int8_t sleep(uint8_t interrupt1, uint8_t mode1, uint8_t interrupt2, uint8_t mode
 }
 
 int8_t smartSleep(uint8_t interrupt1, uint8_t mode1, uint8_t interrupt2, uint8_t mode2, unsigned long ms) {
-	int8_t ret = sleep(interrupt1, mode1, interrupt2, mode2, ms);
-	// notifiy controller about wake up
+	// notifiy controller about going to sleep
 	sendHeartbeat();
 	// listen for incoming messages
 	wait(MY_SMART_SLEEP_WAIT_DURATION);
-	return ret;
+	return sleep(interrupt1, mode1, interrupt2, mode2, ms);
 }
 
 #ifdef MY_NODE_LOCK_FEATURE
@@ -559,4 +556,3 @@ void nodeLock(const char* str) {
 	}
 }
 #endif
-


### PR DESCRIPTION
This is a resubmission of this PR:
https://github.com/mysensors/MySensors/pull/465

Wait for heartbeat is now done before going to sleep, instead of after waking up.

I've pulled in @abmantis commit to give credit where it belongs. Then I've fixed a couple of typos. There seem to be some whitespace fixes in there too. Rebased off development.

Tested with serial gateway and a node with one interrupt activated during smartsleep.