### PR TITLE
Correctly initialize MyMessage

### DIFF
--- a/core/MyMessage.cpp
+++ b/core/MyMessage.cpp
@@ -24,22 +24,27 @@
 
 
 MyMessage::MyMessage()
-  :   last( 0u )
-    , sender( 0u )
-	, destination( 0u ) // Gateway is default destination
-    , version_length( 0u )
-    , command_ack_payload( 0u )
-    , type( 0u )
-    , sensor( 0u )
 {
-    (void)memset(data, 0u, sizeof(data));    
+    clear();
 }
 
 MyMessage::MyMessage(uint8_t _sensor, uint8_t _type)
-  : MyMessage()
 {
+    clear();
 	sensor = _sensor;
-	type = _type;
+	type   = _type;
+}
+
+void MyMessage::clear()
+{
+    last                = 0u;
+    sender              = 0u;
+	destination         = 0u;       // Gateway is default destination
+    version_length      = 0u;
+    command_ack_payload = 0u;
+    type                = 0u;
+    sensor              = 0u;
+    (void)memset(data, 0u, sizeof(data));    
 }
 
 bool MyMessage::isAck() const {

--- a/core/MyMessage.cpp
+++ b/core/MyMessage.cpp
@@ -23,12 +23,21 @@
 #include <stdlib.h>
 
 
-MyMessage::MyMessage() {
-	destination = 0; // Gateway is default destination
+MyMessage::MyMessage()
+  :   last( 0u )
+    , sender( 0u )
+	, destination( 0u ) // Gateway is default destination
+    , version_length( 0u )
+    , command_ack_payload( 0u )
+    , type( 0u )
+    , sensor( 0u )
+{
+    (void)memset(data, 0u, sizeof(data));    
 }
 
-MyMessage::MyMessage(uint8_t _sensor, uint8_t _type) {
-	destination = 0; // Gateway is default destination
+MyMessage::MyMessage(uint8_t _sensor, uint8_t _type)
+  : MyMessage()
+{
 	sensor = _sensor;
 	type = _type;
 }

--- a/core/MyMessage.h
+++ b/core/MyMessage.h
@@ -282,6 +282,11 @@ public:
 
 	char i2h(uint8_t i) const;
 
+    /**
+     * Clear message contents.
+     */
+    void clear();
+
 	/**
 	 * If payload is something else than P_STRING you can have the payload value converted
 	 * into string representation by supplying a buffer with the minimum size of


### PR DESCRIPTION
MyMessage() should initialize all fields, otherwise MyMessages() created on stack will not have all members initialized correctly.