### PR TITLE
Harmonize message type names

### DIFF
--- a/core/MyMessage.h
+++ b/core/MyMessage.h
@@ -163,13 +163,13 @@ typedef enum {
 /// @brief Type of internal messages (for internal messages)
 typedef enum {
 	I_BATTERY_LEVEL			= 0,	//!< Battery level
-	I_TIME					= 1,	//!< Time
+	I_TIME					= 1,	//!< Time (request/response)
 	I_VERSION				= 2,	//!< Version
 	I_ID_REQUEST			= 3,	//!< ID request
 	I_ID_RESPONSE			= 4,	//!< ID response
 	I_INCLUSION_MODE		= 5,	//!< Inclusion mode
-	I_CONFIG				= 6,	//!< Config
-	I_FIND_PARENT			= 7,	//!< Find parent
+	I_CONFIG				= 6,	//!< Config (request/response)
+	I_FIND_PARENT_REQUEST	= 7,	//!< Find parent
 	I_FIND_PARENT_RESPONSE	= 8,	//!< Find parent response
 	I_LOG_MESSAGE			= 9,	//!< Log message
 	I_CHILDREN				= 10,	//!< Children
@@ -180,9 +180,9 @@ typedef enum {
 	I_SIGNING_PRESENTATION	= 15,	//!< Provides signing related preferences (first byte is preference version)
 	I_NONCE_REQUEST			= 16,	//!< Request for a nonce
 	I_NONCE_RESPONSE		= 17,	//!< Payload is nonce data
-	I_HEARTBEAT				= 18,	//!< Heartbeat request
+	I_HEARTBEAT_REQUEST		= 18,	//!< Heartbeat request
 	I_PRESENTATION			= 19,	//!< Presentation message
-	I_DISCOVER				= 20,	//!< Discover request
+	I_DISCOVER_REQUEST		= 20,	//!< Discover request
 	I_DISCOVER_RESPONSE		= 21,	//!< Discover response
 	I_HEARTBEAT_RESPONSE	= 22,	//!< Heartbeat response
 	I_LOCKED				= 23,	//!< Node is locked (reason in string-payload)

--- a/core/MySensorsCore.cpp
+++ b/core/MySensorsCore.cpp
@@ -330,7 +330,7 @@ bool _processInternalMessages() {
 			// Re-send node presentation to controller
 			presentNode();
 		}
-		else if (type == I_HEARTBEAT) {
+		else if (type == I_HEARTBEAT_REQUEST) {
 			sendHeartbeat();
 		}
 		else if (type == I_TIME) {

--- a/core/MySigning.cpp
+++ b/core/MySigning.cpp
@@ -84,11 +84,11 @@ static bool skipSign(MyMessage &msg) {
 		SIGN_DEBUG(PSTR("Skipping security for ACK on command %d type %d\n"), mGetCommand(msg), msg.type);
 		return true;
 	}	else if (mGetCommand(msg) == C_INTERNAL &&
-		(msg.type == I_NONCE_REQUEST	|| msg.type == I_NONCE_RESPONSE			|| msg.type == I_SIGNING_PRESENTATION ||
-		msg.type == I_ID_REQUEST		|| msg.type == I_ID_RESPONSE			||
-		msg.type == I_FIND_PARENT		|| msg.type == I_FIND_PARENT_RESPONSE	||
-		msg.type == I_HEARTBEAT			|| msg.type == I_HEARTBEAT_RESPONSE		||
-		msg.type == I_PING				|| msg.type == I_PONG					||
+		(msg.type == I_NONCE_REQUEST		|| msg.type == I_NONCE_RESPONSE			|| msg.type == I_SIGNING_PRESENTATION ||
+		msg.type == I_ID_REQUEST			|| msg.type == I_ID_RESPONSE			||
+		msg.type == I_FIND_PARENT_REQUEST	|| msg.type == I_FIND_PARENT_RESPONSE	||
+		msg.type == I_HEARTBEAT_REQUEST			|| msg.type == I_HEARTBEAT_RESPONSE		||
+		msg.type == I_PING					|| msg.type == I_PONG					||
 		msg.type == I_REGISTRATION_REQUEST	)) {
 		SIGN_DEBUG(PSTR("Skipping security for command %d type %d\n"), mGetCommand(msg), msg.type);
 		return true;

--- a/core/MyTransport.cpp
+++ b/core/MyTransport.cpp
@@ -101,7 +101,7 @@ void stParentTransition()  {
 		_nc.distance = DISTANCE_INVALID;	// Set distance to max and invalidate parent node ID
 		_nc.parentNodeId = AUTO;
 		// Broadcast find parent request
-		transportRouteMessage(build(_msgTmp, _nc.nodeId, BROADCAST_ADDRESS, NODE_SENSOR_ID, C_INTERNAL, I_FIND_PARENT, false).set(""));
+		transportRouteMessage(build(_msgTmp, _nc.nodeId, BROADCAST_ADDRESS, NODE_SENSOR_ID, C_INTERNAL, I_FIND_PARENT_REQUEST, false).set(""));
 	#endif
 }
 
@@ -509,7 +509,7 @@ void transportProcessMessage() {
 					if (type == I_FIND_PARENT_RESPONSE) {
 						#if !defined(MY_GATEWAY_FEATURE) && !defined(MY_PARENT_NODE_IS_STATIC)
 							if (_transportSM.findingParentNode) {	// only process if find parent active
-								// Reply to a I_FIND_PARENT message. Check if the distance is shorter than we already have.
+								// Reply to a I_FIND_PARENT_REQUEST message. Check if the distance is shorter than we already have.
 								uint8_t distance = _msg.getByte();
 								TRANSPORT_DEBUG(PSTR("TSF:MSG:FPAR RES,ID=%d,D=%d\n"), sender, distance);	// find parent response
 								if (isValidDistance(distance)) {
@@ -579,7 +579,7 @@ void transportProcessMessage() {
 		if (command == C_INTERNAL) {
 			if (isTransportReady()) {
 				// only reply if node is fully operational
-				if (type == I_FIND_PARENT) {
+				if (type == I_FIND_PARENT_REQUEST) {
 					#if defined(MY_REPEATER_FEATURE)
 						if (sender != _nc.parentNodeId) {	// no circular reference
 							TRANSPORT_DEBUG(PSTR("TSF:MSG:FPAR REQ,ID=%d\n"), sender);	// FPR: find parent request
@@ -603,7 +603,7 @@ void transportProcessMessage() {
 				return; // no further processing required	
 				}
 			}
-			if (type == I_DISCOVER) {
+			if (type == I_DISCOVER_REQUEST) {
 				if (last == _nc.parentNodeId) {
 					// random wait to minimize collisions
 					delay(hwMillis() & 0x3ff);


### PR DESCRIPTION
Rename internal messages to adhere to _request/_response naming scheme (if functionality not affected):
- I_DISCOVER -> I_DISCOVER_REQUEST
- I_HEARTBEAT -> I_HEARTBEAT_REQUEST
- I_FIND_PARENT -> I_FIND_PARENT_REQUEST
