### PR TITLE
Correct config for UDP GatewayESP8266

### DIFF
--- a/examples/GatewayESP8266/GatewayESP8266.ino
+++ b/examples/GatewayESP8266/GatewayESP8266.ino
@@ -127,10 +127,9 @@
 #define MY_DEFAULT_TX_LED_PIN  16  // the PCB, on board LED
 
 #if defined(MY_USE_UDP)
-  #include <WiFiUDP.h>
-#else
-  #include <ESP8266WiFi.h>
+  #include <WiFiUdp.h> // Case sensitive systems as Linux & OS X, look for the correct upper/lower case in the library name
 #endif
+#include <ESP8266WiFi.h>
 
 #include <MySensors.h>
 


### PR DESCRIPTION
- Added a note to remember users about the upper/lower case <br />for Linux and OS X<br /><br />- #include \<ESP8266WiFi.h\> must be included <br />no matter MY_USE_UDP is set or not.