### PR TITLE
Set WDT to 1sec in hwReboot

### DIFF
--- a/core/MyHw.h
+++ b/core/MyHw.h
@@ -39,7 +39,7 @@
 #define hwDigitalWrite(__pin, __value)
 #define hwInit() MY_SERIALDEVICE.begin(BAUD_RATE)
 #define hwWatchdogReset() wdt_reset()
-#define hwReboot() wdt_enable(WDTO_15MS); while (1)
+#define hwReboot() wdt_enable(WDTO_1S); while (1)
 #define hwMillis() millis()
 
 void hwReadConfigBlock(void* buf, void* adr, size_t length);


### PR DESCRIPTION
This gives even a slow 1Mhz node, running wihtout any bootloader,
the chance to reboot.
Even disabling WDT in before() is not necessary, because MySensors framework
can handle all WDT setup within that 1sec.
If you do not want to increase that timeout, slow nodes would have to use the before() function like this.
void before() {
  MCUSR = 0;
  wdt_disable();
}