### PR TITLE
Add define to replace AltSoftSerial object with user's serial object (e.g. Serial1)

### DIFF
--- a/MySensors.h
+++ b/MySensors.h
@@ -223,7 +223,9 @@
 		#include "drivers/RF24/RF24.cpp"
 		#include "core/MyTransportNRF24.cpp"
 	#elif defined(MY_RS485)
-		#include "drivers/AltSoftSerial/AltSoftSerial.cpp"
+		#if !defined(MY_RS485_SERIAL)
+			#include "drivers/AltSoftSerial/AltSoftSerial.cpp"
+		#endif
 		#include "core/MyTransportRS485.cpp"
 	#elif defined(MY_RADIO_RFM69)
 		#include "drivers/RFM69/RFM69.cpp"

--- a/core/MyTransportRS485.cpp
+++ b/core/MyTransportRS485.cpp
@@ -92,7 +92,11 @@ unsigned char _recSender;
 unsigned char _recCS;
 unsigned char _recCalcCS;
 
+#if defined(MY_RS485_SERIAL)
+HardwareSerial& _dev = MY_RS485_SERIAL;
+#else
 AltSoftSerial _dev;
+#endif
 
 
 unsigned char _nodeId;


### PR DESCRIPTION
I have tested this with Serial1 on MEGA board. It worked OK. However when connecting to AltSoftSerial node, the connection was not reliable.