### PR TITLE
HAL for digitalRead/Write() and pinMode()

### DIFF
--- a/MySensors.h
+++ b/MySensors.h
@@ -66,6 +66,7 @@
 	//#define F(x) (x)
 	#include "core/MyHwESP8266.cpp"
 #elif defined(ARDUINO_ARCH_AVR)
+	#include "drivers/AVR/DigitalWriteFast/digitalWriteFast.h"
 	#include "core/MyHwATMega328.cpp"
 #elif defined(ARDUINO_ARCH_SAMD)
         #include "core/MyHwSAMD.cpp"

--- a/core/MyGatewayTransportEthernet.cpp
+++ b/core/MyGatewayTransportEthernet.cpp
@@ -87,14 +87,14 @@ typedef struct
 		if (enable)
 		{
 			// Pull up pin
-			pinMode(MY_W5100_SPI_EN, INPUT);
-			digitalWrite(MY_W5100_SPI_EN, HIGH);
+			hwPinMode(MY_W5100_SPI_EN, INPUT);
+			hwDigitalWrite(MY_W5100_SPI_EN, HIGH);
 		}
 		else
 		{
 			// Ground pin
-			pinMode(MY_W5100_SPI_EN, OUTPUT);
-			digitalWrite(MY_W5100_SPI_EN, LOW);
+			hwPinMode(MY_W5100_SPI_EN, OUTPUT);
+			hwDigitalWrite(MY_W5100_SPI_EN, LOW);
 		}
 	}
 #else

--- a/core/MyHwATMega328.h
+++ b/core/MyHwATMega328.h
@@ -58,7 +58,10 @@ do { 																\
 
 // Define these as macros to save valuable space
 
-#define hwDigitalWrite(__pin, __value) (digitalWrite(__pin, __value))
+#define hwDigitalWrite(__pin, __value) digitalWriteFast(__pin, __value)
+#define hwDigitalRead(__pin) digitalReadFast(__pin)
+#define hwPinMode(__pin, __value) pinModeFast(__pin, __value)
+
 
 #if defined(MY_DISABLED_SERIAL)
 	#define hwInit()
@@ -78,7 +81,6 @@ do { 																\
 	#define hwWriteConfig(__pos, __value) (eeprom_update_byte((uint8_t*)(__pos), (__value)))
 #endif
 
-//
 #define hwReadConfigBlock(__buf, __pos, __length) (eeprom_read_block((__buf), (void*)(__pos), (__length)))
 #define hwWriteConfigBlock(__pos, __buf, __length) (eeprom_write_block((void*)(__pos), (void*)__buf, (__length)))
 

--- a/core/MyHwESP8266.h
+++ b/core/MyHwESP8266.h
@@ -33,8 +33,9 @@
 
 
 // Define these as macros to save valuable space
-
-#define hwDigitalWrite(__pin, __value) (digitalWrite(__pin, __value))
+#define hwDigitalWrite(__pin, __value) digitalWrite(__pin, __value)
+#define hwDigitalRead(__pin) digitalRead(__pin)
+#define hwPinMode(__pin, __value) pinMode(__pin, __value)
 
 #if defined(MY_DISABLED_SERIAL)
 	#define hwInit()

--- a/core/MyHwLinuxGeneric.h
+++ b/core/MyHwLinuxGeneric.h
@@ -33,8 +33,11 @@
 
 #define MY_SERIALDEVICE Serial
 
-// Define these as macros (do nothing)
-#define hwDigitalWrite(__pin, __value)
+// Define these as macros
+#define hwDigitalWrite(__pin, __value) digitalWrite(__pin, __value)
+#define hwDigitalRead(__pin) digitalRead(__pin)
+#define hwPinMode(__pin, __value) pinMode(__pin, __value)
+
 #define hwWatchdogReset()
 #define hwReboot()
 #define hwMillis() millis()

--- a/core/MyHwSAMD.h
+++ b/core/MyHwSAMD.h
@@ -34,17 +34,18 @@
 #define max(a,b) ((a)>(b)?(a):(b))
 #define snprintf_P(s, f, ...) snprintf((s), (f), __VA_ARGS__)
 
+uint8_t configBlock[1024];
 
 // Define these as macros to save valuable space
-
-uint8_t configBlock[1024];
-#define hwDigitalWrite(__pin, __value) (digitalWrite(__pin, __value))
-void hwInit();
-void hwWatchdogReset();
-void hwReboot();
+#define hwDigitalWrite(__pin, __value) digitalWrite(__pin, __value)
+#define hwDigitalRead(__pin) digitalRead(__pin)
+#define hwPinMode(__pin, __value) pinMode(__pin, __value)
 #define hwMillis() millis()
 #define hwRandomNumberInit() randomSeed(analogRead(MY_SIGNING_SOFT_RANDOMSEED_PIN))
 
+void hwInit();
+void hwWatchdogReset();
+void hwReboot();
 void hwReadConfigBlock(void* buf, void* adr, size_t length);
 void hwWriteConfigBlock(void* buf, void* adr, size_t length);
 void hwWriteConfig(int adr, uint8_t value);

--- a/core/MyInclusionMode.cpp
+++ b/core/MyInclusionMode.cpp
@@ -29,8 +29,8 @@ inline void inclusionInit() {
 	_inclusionMode = false;
 	#if defined(MY_INCLUSION_BUTTON_FEATURE)
 		// Setup digital in that triggers inclusion mode
-		pinMode(MY_INCLUSION_MODE_BUTTON_PIN, INPUT);
-		digitalWrite(MY_INCLUSION_MODE_BUTTON_PIN, HIGH);
+		hwPinMode(MY_INCLUSION_MODE_BUTTON_PIN, INPUT);
+		hwDigitalWrite(MY_INCLUSION_MODE_BUTTON_PIN, HIGH);
 	#endif
 
 }
@@ -49,7 +49,7 @@ void inclusionModeSet(bool newMode) {
 
 inline void inclusionProcess() {
 	#ifdef MY_INCLUSION_BUTTON_FEATURE
-	if (!_inclusionMode && digitalRead(MY_INCLUSION_MODE_BUTTON_PIN) == MY_INCLUSION_BUTTON_PRESSED) {
+	if (!_inclusionMode && hwDigitalRead(MY_INCLUSION_MODE_BUTTON_PIN) == MY_INCLUSION_BUTTON_PRESSED) {
 		// Start inclusion mode
 		inclusionModeSet(true);
 	}

--- a/core/MyTransportRS485.cpp
+++ b/core/MyTransportRS485.cpp
@@ -63,8 +63,8 @@
 
 
 #if defined(MY_RS485_DE_PIN)
-	#define assertDE() digitalWrite(MY_RS485_DE_PIN, HIGH); delayMicroseconds(5)
-	#define deassertDE() digitalWrite(MY_RS485_DE_PIN, LOW)
+	#define assertDE() hwDigitalWrite(MY_RS485_DE_PIN, HIGH); delayMicroseconds(5)
+	#define deassertDE() hwDigitalWrite(MY_RS485_DE_PIN, LOW)
 
 #else
 	#define assertDE()
@@ -258,7 +258,7 @@ bool transportSend(uint8_t to, const void* data, uint8_t len)
 	}
 
 	#if defined(MY_RS485_DE_PIN)
-		digitalWrite(MY_RS485_DE_PIN, HIGH);
+		hwDigitalWrite(MY_RS485_DE_PIN, HIGH);
 		delayMicroseconds(5);
 	#endif
 
@@ -300,7 +300,7 @@ bool transportSend(uint8_t to, const void* data, uint8_t len)
 			#endif
 			#endif
 		#endif
-		digitalWrite(MY_RS485_DE_PIN, LOW);
+		hwDigitalWrite(MY_RS485_DE_PIN, LOW);
 	#endif
     return true;
 }
@@ -312,8 +312,8 @@ bool transportInit() {
 	_dev.begin(MY_RS485_BAUD_RATE);
     _serialReset();
 	#if defined(MY_RS485_DE_PIN)
-    	pinMode(MY_RS485_DE_PIN, OUTPUT);
-        digitalWrite(MY_RS485_DE_PIN, LOW);
+    	hwPinMode(MY_RS485_DE_PIN, OUTPUT);
+        hwDigitalWrite(MY_RS485_DE_PIN, LOW);
 	#endif
     return true;
 }

--- a/drivers/AVR/DigitalWriteFast/digitalWriteFast.h
+++ b/drivers/AVR/DigitalWriteFast/digitalWriteFast.h
@@ -1,0 +1,95 @@
+/*
+ * Optimized digital functions for AVR microcontrollers
+ * based on http://code.google.com/p/digitalwritefast
+ */
+
+#ifndef __digitalWriteFast_h_
+#define __digitalWriteFast_h_
+
+#if defined(ARDUINO_AVR_MEGA) || defined(ARDUINO_AVR_MEGA1280) || defined(ARDUINO_AVR_MEGA2560) || defined(__AVR_ATmega1280__) || defined(__AVR_ATmega1281__) || defined(__AVR_ATmega2560__) || defined(__AVR_ATmega2561__)
+	#define __digitalPinToPortReg(__pin) \
+		(((__pin) >= 22 && (__pin) <= 29) ? &PORTA : \
+		((((__pin) >= 10 && (__pin) <= 13) || ((__pin) >= 50 && (__pin) <= 53)) ? &PORTB : \
+		(((__pin) >= 30 && (__pin) <= 37) ? &PORTC : \
+		((((__pin) >= 18 && (__pin) <= 21) || (__pin) == 38) ? &PORTD : \
+		((((__pin) <= 3) || (__pin) == 5) ? &PORTE : \
+		(((__pin) >= 54 && (__pin) <= 61) ? &PORTF : \
+		((((__pin) >= 39 && (__pin) <= 41) || (__pin) == 4) ? &PORTG : \
+		((((__pin) >= 6 && (__pin) <= 9) || (__pin) == 16 || (__pin) == 17) ? &PORTH : \
+		(((__pin) == 14 || (__pin) == 15) ? &PORTJ : \
+		(((__pin) >= 62 && (__pin) <= 69) ? &PORTK : &PORTL))))))))))
+	#define __digitalPinToDDRReg(__pin) \
+		(((__pin) >= 22 && (__pin) <= 29) ? &DDRA : \
+		((((__pin) >= 10 && (__pin) <= 13) || ((__pin) >= 50 && (__pin) <= 53)) ? &DDRB : \
+		(((__pin) >= 30 && (__pin) <= 37) ? &DDRC : \
+		((((__pin) >= 18 && (__pin) <= 21) || (__pin) == 38) ? &DDRD : \
+		((((__pin) <= 3) || (__pin) == 5) ? &DDRE : \
+		(((__pin) >= 54 && (__pin) <= 61) ? &DDRF : \
+		((((__pin) >= 39 && (__pin) <= 41) || (__pin) == 4) ? &DDRG : \
+		((((__pin) >= 6 && (__pin) <= 9) || (__pin) == 16 || (__pin) == 17) ? &DDRH : \
+		(((__pin) == 14 || (__pin) == 15) ? &DDRJ : \
+		(((__pin) >= 62 && (__pin) <= 69) ? &DDRK : &DDRL))))))))))
+	#define __digitalPinToPINReg(__pin) \
+		(((__pin) >= 22 && (__pin) <= 29) ? &PINA : \
+		((((__pin) >= 10 && (__pin) <= 13) || ((__pin) >= 50 && (__pin) <= 53)) ? &PINB : \
+		(((__pin) >= 30 && (__pin) <= 37) ? &PINC : \
+		((((__pin) >= 18 && (__pin) <= 21) || (__pin) == 38) ? &PIND : \
+		((((__pin) <= 3) || (__pin) == 5) ? &PINE : \
+		(((__pin) >= 54 && (__pin) <= 61) ? &PINF : \
+		((((__pin) >= 39 && (__pin) <= 41) || (__pin) == 4) ? &PING : \
+		((((__pin) >= 6 && (__pin) <= 9) || (__pin) == 16 || (__pin) == 17) ? &PINH : \
+		(((__pin) == 14 || (__pin) == 15) ? &PINJ : \
+		(((__pin) >= 62 && (__pin) <= 69) ? &PINK : &PINL))))))))))
+	#define __digitalPinToBit(__pin) \
+		(((__pin) >=  7 && (__pin) <=  9) ? (__pin) - 3 : \
+		(((__pin) >= 10 && (__pin) <= 13) ? (__pin) - 6 : \
+		(((__pin) >= 22 && (__pin) <= 29) ? (__pin) - 22 : \
+		(((__pin) >= 30 && (__pin) <= 37) ? 37 - (__pin) : \
+		(((__pin) >= 39 && (__pin) <= 41) ? 41 - (__pin) : \
+		(((__pin) >= 42 && (__pin) <= 49) ? 49 - (__pin) : \
+		(((__pin) >= 50 && (__pin) <= 53) ? 53 - (__pin) : \
+		(((__pin) >= 54 && (__pin) <= 61) ? (__pin) - 54 : \
+		(((__pin) >= 62 && (__pin) <= 69) ? (__pin) - 62 : \
+		(((__pin) == 0 || (__pin) == 15 || (__pin) == 17 || (__pin) == 21) ? 0 : \
+		(((__pin) == 1 || (__pin) == 14 || (__pin) == 16 || (__pin) == 20) ? 1 : \
+		(((__pin) == 19) ? 2 : \
+		(((__pin) == 5 || (__pin) == 6 || (__pin) == 18) ? 3 : \
+		(((__pin) == 2) ? 4 : \
+		(((__pin) == 3 || (__pin) == 4) ? 5 : 7)))))))))))))))
+#elif defined(__AVR_ATmega644__) || defined(__AVR_ATmega644P__)
+	#define __digitalPinToPortReg(__pin)	(((__pin) <= 7) ? &PORTB : (((__pin) >= 8 && (__pin) <= 15) ? &PORTD : (((__pin) >= 16 && (__pin) <= 23) ? &PORTC : &PORTA)))
+	#define __digitalPinToDDRReg(__pin)		(((__pin) <= 7) ? &DDRB : (((__pin) >= 8 && (__pin) <= 15) ? &DDRD : (((__pin) >= 8 && (__pin) <= 15) ? &DDRC : &DDRA)))
+	#define __digitalPinToPINReg(__pin)		(((__pin) <= 7) ? &PINB : (((__pin) >= 8 && (__pin) <= 15) ? &PIND : (((__pin) >= 8 && (__pin) <= 15) ? &PINC : &PINA)))
+	#define __digitalPinToBit(__pin)		(((__pin) <= 7) ? (__pin) : (((__pin) >= 8 && (__pin) <= 15) ? (__pin) - 8 : (((__pin) >= 16 && (__pin) <= 23) ? (__pin) - 16 : (__pin) - 24)))
+#elif defined(ARDUINO_AVR_LEONARDO) || defined(__AVR_ATmega16U4__) || defined(__AVR_ATmega32U4__)
+	#define __digitalPinToPortReg(__pin)	((((__pin) <= 4) || (__pin) == 6 || (__pin) == 12 || (__pin) == 24 || (__pin) == 25 || (__pin) == 29) ? &PORTD : (((__pin) == 5 || (__pin) == 13) ? &PORTC : (((__pin) >= 18 && (__pin) <= 23)) ? &PORTF : (((__pin) == 7) ? &PORTE : &PORTB)))
+	#define __digitalPinToDDRReg(__pin)		((((__pin) <= 4) || (__pin) == 6 || (__pin) == 12 || (__pin) == 24 || (__pin) == 25 || (__pin) == 29) ? &DDRD : (((__pin) == 5 || (__pin) == 13) ? &DDRC : (((__pin) >= 18 && (__pin) <= 23)) ? &DDRF : (((__pin) == 7) ? &DDRE : &DDRB)))
+	#define __digitalPinToPINReg(__pin)		((((__pin) <= 4) || (__pin) == 6 || (__pin) == 12 || (__pin) == 24 || (__pin) == 25 || (__pin) == 29) ? &PIND : (((__pin) == 5 || (__pin) == 13) ? &PINC : (((__pin) >= 18 && (__pin) <= 23)) ? &PINF : (((__pin) == 7) ? &PINE : &PINB)))
+	#define __digitalPinToBit(__pin)		(((__pin) >= 8 && (__pin) <= 11) ? (__pin) - 4 : (((__pin) >= 18 && (__pin) <= 21) ? 25 - (__pin) : (((__pin) == 0) ? 2 : (((__pin) == 1) ? 3 : (((__pin) == 2) ? 1 : (((__pin) == 3) ? 0 : (((__pin) == 4) ? 4 : (((__pin) == 6) ? 7 : (((__pin) == 13) ? 7 : (((__pin) == 14) ? 3 : (((__pin) == 15) ? 1 : (((__pin) == 16) ? 2 : (((__pin) == 17) ? 0 : (((__pin) == 22) ? 1 : (((__pin) == 23) ? 0 : (((__pin) == 24) ? 4 : (((__pin) == 25) ? 7 : (((__pin) == 26) ? 4 : (((__pin) == 27) ? 5 : 6 )))))))))))))))))))
+#elif defined(ARDUINO_AVR_UNO) || defined(ARDUINO_AVR_DUEMILANOVE) || defined(__AVR_ATmega328__) || defined(__AVR_ATmega328P__) || defined(__AVR_ATmega328PB__)
+	#if defined(__AVR_ATmega328PB__)
+		#define __digitalPinToPortReg(__pin)	(((__pin) <= 7) ? &PORTD : (((__pin) >= 8 && (__pin) <= 13) ? &PORTB : (((__pin) >= 14 && (__pin) <= 19) ? &PORTC : &PORTE)))
+		#define __digitalPinToDDRReg(__pin)		(((__pin) <= 7) ? &DDRD : (((__pin) >= 8 && (__pin) <= 13) ? &DDRB : (((__pin) >= 14 && (__pin) <= 19) ? &DDRC : &DDRE)))
+		#define __digitalPinToPINReg(__pin)		(((__pin) <= 7) ? &PIND : (((__pin) >= 8 && (__pin) <= 13) ? &PINB : (((__pin) >= 14 && (__pin) <= 19) ? &PINC : &PINE)))
+		#define __digitalPinToBit(__pin)		(((__pin) <= 7) ? (__pin) : (((__pin) >= 8 && (__pin) <= 13) ? (__pin) - 8 : (((__pin) >= 14 && (__pin) <= 19) ? (__pin) - 14 : (((__pin) >= 20 && (__pin) <= 21) ? (__pin) - 18 : (__pin) - 22))))
+	#else
+		#define __digitalPinToPortReg(__pin)	(((__pin) <= 7) ? &PORTD : (((__pin) >= 8 && (__pin) <= 13) ? &PORTB : &PORTC))
+		#define __digitalPinToDDRReg(__pin)		(((__pin) <= 7) ? &DDRD : (((__pin) >= 8 && (__pin) <= 13) ? &DDRB : &DDRC))
+		#define __digitalPinToPINReg(__pin)		(((__pin) <= 7) ? &PIND : (((__pin) >= 8 && (__pin) <= 13) ? &PINB : &PINC))
+		#define __digitalPinToBit(__pin)		(((__pin) <= 7) ? (__pin) : (((__pin) >= 8 && (__pin) <= 13) ? (__pin) - 8 : (__pin) - 14))
+	#endif
+#endif
+
+#if defined(ARDUINO_ARCH_AVR)
+	#if !defined(digitalWriteFast)
+		#define digitalWriteFast(__pin, __value) do { if (__builtin_constant_p(__pin) && __builtin_constant_p(__value)) { bitWrite(*__digitalPinToPortReg(__pin), __digitalPinToBit(__pin), (__value)); } else { digitalWrite((__pin), (__value)); } } while (0)
+	#endif
+	#if !defined(pinModeFast)
+		#define pinModeFast(__pin, __value) do { if (__builtin_constant_p(__pin) && __builtin_constant_p(__value)) { bitWrite(*__digitalPinToDDRReg(__pin), __digitalPinToBit(__pin), (__value)); } else { pinMode((__pin), (__value)); } } while (0)
+	#endif
+	#if !defined(digitalReadFast)
+		#define digitalReadFast(__pin) ( (bool) (__builtin_constant_p(__pin) ) ? (( bitRead(*__digitalPinToPINReg(__pin), __digitalPinToBit(__pin))) ) : digitalRead((__pin)) )
+	#endif
+#endif
+
+#endif

--- a/drivers/AltSoftSerial/AltSoftSerial.cpp
+++ b/drivers/AltSoftSerial/AltSoftSerial.cpp
@@ -76,9 +76,9 @@ void AltSoftSerial::init(uint32_t cycles_per_bit)
 	}
 	ticks_per_bit = cycles_per_bit;
 	rx_stop_ticks = cycles_per_bit * 37 / 4;
-	pinMode(INPUT_CAPTURE_PIN, INPUT_PULLUP);
-	digitalWrite(OUTPUT_COMPARE_A_PIN, HIGH);
-	pinMode(OUTPUT_COMPARE_A_PIN, OUTPUT);
+	hwPinMode(INPUT_CAPTURE_PIN, INPUT_PULLUP);
+	hwDigitalWrite(OUTPUT_COMPARE_A_PIN, HIGH);
+	hwPinMode(OUTPUT_COMPARE_A_PIN, OUTPUT);
 	rx_state = 0;
 	rx_buffer_head = 0;
 	rx_buffer_tail = 0;

--- a/drivers/RF24/RF24.cpp
+++ b/drivers/RF24/RF24.cpp
@@ -35,11 +35,11 @@ LOCAL uint8_t MY_RF24_NODE_ADDRESS = AUTO;
 #endif
 
 LOCAL void RF24_csn(bool level) {
-	digitalWrite(MY_RF24_CS_PIN, level);
+	hwDigitalWrite(MY_RF24_CS_PIN, level);
 }
 
 LOCAL void RF24_ce(bool level) {
-	digitalWrite(MY_RF24_CE_PIN, level);
+	hwDigitalWrite(MY_RF24_CE_PIN, level);
 }
 
 LOCAL uint8_t RF24_spiMultiByteTransfer(uint8_t cmd, uint8_t* buf, uint8_t len, bool aReadMode) {
@@ -338,10 +338,10 @@ LOCAL bool RF24_initialize(void) {
 	(void)RF24_getObserveTX;
 
 	// Initialize pins
-	pinMode(MY_RF24_CE_PIN,OUTPUT);
-	pinMode(MY_RF24_CS_PIN,OUTPUT);
+	hwPinMode(MY_RF24_CE_PIN,OUTPUT);
+	hwPinMode(MY_RF24_CS_PIN,OUTPUT);
 	#if defined(MY_RX_MESSAGE_BUFFER_FEATURE)
-		pinMode(MY_RF24_IRQ_PIN,INPUT);
+		hwPinMode(MY_RF24_IRQ_PIN,INPUT);
 	#endif
 	// Initialize SPI
 	_SPI.begin();

--- a/drivers/RFM69/RFM69.cpp
+++ b/drivers/RFM69/RFM69.cpp
@@ -87,8 +87,8 @@ bool RFM69::initialize(uint8_t freqBand, uint8_t nodeID, uint8_t networkID)
     {255, 0}
   };
 
-  digitalWrite(_slaveSelectPin, HIGH);
-  pinMode(_slaveSelectPin, OUTPUT);
+  hwDigitalWrite(_slaveSelectPin, HIGH);
+  hwPinMode(_slaveSelectPin, OUTPUT);
   SPI.begin();
   unsigned long start = millis();
   uint8_t timeout = 50;
@@ -318,15 +318,15 @@ void RFM69::sendFrame(uint8_t toAddress, const void* buffer, uint8_t bufferSize,
   // no need to wait for transmit mode to be ready since its handled by the radio
   setMode(RF69_MODE_TX);
   uint32_t txStart = millis();
-  while (digitalRead(_interruptPin) == 0 && millis() - txStart < RF69_TX_LIMIT_MS); // wait for DIO0 to turn HIGH signalling transmission finish
+  while (hwDigitalRead(_interruptPin) == 0 && millis() - txStart < RF69_TX_LIMIT_MS); // wait for DIO0 to turn HIGH signalling transmission finish
   //while (readReg(REG_IRQFLAGS2) & RF_IRQFLAGS2_PACKETSENT == 0x00); // wait for ModeReady
   setMode(RF69_MODE_STANDBY);
 }
 
 // internal function - interrupt gets called when a packet is received
 void RFM69::interruptHandler() {
-  //pinMode(4, OUTPUT);
-  //digitalWrite(4, 1);
+  //hwPinMode(4, OUTPUT);
+  //hwDigitalWrite(4, 1);
   if (_mode == RF69_MODE_RX && (readReg(REG_IRQFLAGS2) & RF_IRQFLAGS2_PAYLOADREADY))
   {
     //RSSI = readRSSI();
@@ -342,7 +342,7 @@ void RFM69::interruptHandler() {
       PAYLOADLEN = 0;
       unselect();
       receiveBegin();
-      //digitalWrite(4, 0);
+      //hwDigitalWrite(4, 0);
       return;
     }
 
@@ -364,7 +364,7 @@ void RFM69::interruptHandler() {
     setMode(RF69_MODE_RX);
   }
   RSSI = readRSSI();
-  //digitalWrite(4, 0);
+  //hwDigitalWrite(4, 0);
 }
 
 // internal function
@@ -464,12 +464,12 @@ void RFM69::select() {
   SPI.setDataMode(SPI_MODE0);
   SPI.setBitOrder(MSBFIRST);
   SPI.setClockDivider(SPI_CLOCK_DIV4); // decided to slow down from DIV2 after SPI stalling in some instances, especially visible on mega1284p when RFM69 and FLASH chip both present
-  digitalWrite(_slaveSelectPin, LOW);
+  hwDigitalWrite(_slaveSelectPin, LOW);
 }
 
 // unselect the RFM69 transceiver (set CS high, restore SPI settings)
 void RFM69::unselect() {
-  digitalWrite(_slaveSelectPin, HIGH);
+  hwDigitalWrite(_slaveSelectPin, HIGH);
   // restore SPI settings to what they were before talking to RFM69
 #if defined (SPCR) && defined (SPSR)
   SPCR = _SPCR;
@@ -504,8 +504,8 @@ void RFM69::setHighPowerRegs(bool onOff) {
 // set the slave select (CS) pin 
 void RFM69::setCS(uint8_t newSPISlaveSelect) {
   _slaveSelectPin = newSPISlaveSelect;
-  digitalWrite(_slaveSelectPin, HIGH);
-  pinMode(_slaveSelectPin, OUTPUT);
+  hwDigitalWrite(_slaveSelectPin, HIGH);
+  hwPinMode(_slaveSelectPin, OUTPUT);
 }
 
 //for debugging

--- a/drivers/SPIFlash/SPIFlash.cpp
+++ b/drivers/SPIFlash/SPIFlash.cpp
@@ -72,12 +72,12 @@ void SPIFlash::select() {
   SPI.setClockDivider(SPI_CLOCK_DIV4); //decided to slow down from DIV2 after SPI stalling in some instances, especially visible on mega1284p when RFM69 and FLASH chip both present
   SPI.begin();
 #endif
-  digitalWrite(_slaveSelectPin, LOW);
+  hwDigitalWrite(_slaveSelectPin, LOW);
 }
 
 /// UNselect the flash chip
 void SPIFlash::unselect() {
-  digitalWrite(_slaveSelectPin, HIGH);
+  hwDigitalWrite(_slaveSelectPin, HIGH);
   //restore SPI settings to what they were before talking to the FLASH chip
 #ifdef SPI_HAS_TRANSACTION
   SPI.endTransaction();
@@ -97,7 +97,7 @@ boolean SPIFlash::initialize()
   _SPCR = SPCR;
   _SPSR = SPSR;
 #endif
-  pinMode(_slaveSelectPin, OUTPUT);
+  hwPinMode(_slaveSelectPin, OUTPUT);
 #ifdef SPI_HAS_TRANSACTION
   _settings = SPISettings(4000000, MSBFIRST, SPI_MODE0);
 #endif

--- a/examples/GatewayW5100/GatewayW5100.ino
+++ b/examples/GatewayW5100/GatewayW5100.ino
@@ -32,7 +32,7 @@
  * The GW code is designed for Arduino 328p / 16MHz.  ATmega168 does not have enough memory to run this program.
  *
  * LED purposes:
- * - To use the feature, uncomment WITH_LEDS_BLINKING in MyConfig.h
+ * - To use the feature, uncomment MY_DEFAULT_xxx_LED_PIN in the sketch below
  * - RX (green) - blink fast on radio message recieved. In inclusion mode will blink fast only on presentation recieved
  * - TX (yellow) - blink fast on radio message transmitted. In inclusion mode will blink slowly
  * - ERR (red) - fast blink on error during transmission error or recieve crc error
@@ -106,7 +106,7 @@
 // Uncomment to override default HW configurations
 //#define MY_DEFAULT_ERR_LED_PIN 7  // Error led pin
 //#define MY_DEFAULT_RX_LED_PIN  8  // Receive led pin
-//#define MY_DEFAULT_TX_LED_PIN  9  // the PCB, on board LED
+//#define MY_DEFAULT_TX_LED_PIN  9  // Transmit led pin
 
 
 #if defined(MY_USE_UDP)


### PR DESCRIPTION
- Pin IO abstraction for all architectures
- use digitalWriteFast(), digitalReadFast() & pinModeFast() for AVR: speeding up pin access & reduce flash