### PR TITLE
RPi: make directly attached RFM69 module work

### DIFF
--- a/configure
+++ b/configure
@@ -47,11 +47,13 @@ MySensors options:
                                 MQTT publish topic prefix.
     --my-mqtt-subscribe-topic-prefix=<PREFIX>
                                 MQTT subscribe topic prefix.
-    --my-radio=[none|nrf24]     Radio type, set to none to disable radio feature. [rf24]
+    --my-radio=[none|nrf24|rfm69]
+                                Radio type, set to none to disable radio feature. [rf24]
     --my-rf24-channel=<0-125>   RF channel for the sensor net, 0-125. [76]
     --my-rf24-pa-level=[RF24_PA_MAX|RF24_PA_LOW]
                                 RF24 PA level. [RF24_PA_MAX]
     --my-rf24-irq-pin=<PIN>     Pin number connected to nRF24L01 IRQ pin.
+    --my-rf69-irq-pin=<PIN>     Pin number connected to RFM69 IRQ pin.
     --my-rx-message-buffer-size=<SIZE>
                                 Buffer size for incoming messages when using rf24 interrupts. [20]
     --my-leds-err-pin=<PIN>     Error LED pin.
@@ -286,6 +288,9 @@ for opt do
     --my-rf24-irq-pin=*)
         CXXFLAGS="-DMY_RX_MESSAGE_BUFFER_FEATURE -DMY_RF24_IRQ_PIN=${optarg} $CXXFLAGS"
         ;;
+    --my-rf69-irq-pin=*)
+        CXXFLAGS="-DMY_RF69_IRQ_PIN=${optarg} -DMY_RF69_IRQ_NUM=${optarg} $CXXFLAGS"
+        ;;
     --my-rx-message-buffer-size=*)
         CXXFLAGS="-DMY_RX_MESSAGE_BUFFER_SIZE=${optarg} $CXXFLAGS"
         ;;
@@ -350,6 +355,8 @@ fi
 
 if [[ ${radio_type} == "nrf24" ]]; then
     CXXFLAGS="-DMY_RADIO_NRF24 $CXXFLAGS"
+elif [[ ${radio_type} == "rfm69" ]]; then
+    CXXFLAGS="-DMY_RADIO_RFM69 $CXXFLAGS"
 fi
 
 LDFLAGS="-pthread $LDFLAGS"

--- a/configure
+++ b/configure
@@ -328,6 +328,10 @@ fi
 CXXFLAGS="$CPUFLAGS -Ofast -g -Wall -Wextra $CXXFLAGS"
 CFLAGS="-Ofast -g -Wall -Wextra $CFLAGS"
 
+if [[ ${TYPE:0:3} == "RPi" ]]; then
+    CXXFLAGS+="-std=c++11 "
+fi
+
 if [[ $TYPE == "RPi2" || $TYPE == "RPi3" || $REV == "0010" ]]; then
     CXXFLAGS+="-D__RPI_BPLUS"
 fi

--- a/drivers/RFM69/RFM69.cpp
+++ b/drivers/RFM69/RFM69.cpp
@@ -323,6 +323,19 @@ void RFM69::sendFrame(uint8_t toAddress, const void* buffer, uint8_t bufferSize,
 
   // write to FIFO
   select();
+#ifdef LINUX_ARCH_RASPBERRYPI
+  char data[RF69_MAX_DATA_LEN + 5];
+  data[0] = REG_FIFO | 0x80;
+  data[1] = bufferSize + 3;
+  data[2] = toAddress;
+  data[3] = _address;
+  data[4] = CTLbyte;
+
+  for (uint8_t i = 0; i < bufferSize; i++) {
+    data[i + 5] = ((char*) buffer)[i];
+  }
+  SPI.transfern(data, bufferSize + 5);
+#else
   SPI.transfer(REG_FIFO | 0x80);
   SPI.transfer(bufferSize + 3);
   SPI.transfer(toAddress);
@@ -332,6 +345,7 @@ void RFM69::sendFrame(uint8_t toAddress, const void* buffer, uint8_t bufferSize,
   for (uint8_t i = 0; i < bufferSize; i++) {
     SPI.transfer(((uint8_t*) buffer)[i]);
   }
+#endif
   unselect();
 
   // no need to wait for transmit mode to be ready since its handled by the radio
@@ -351,10 +365,18 @@ void RFM69::interruptHandler() {
     //RSSI = readRSSI();
     setMode(RF69_MODE_STANDBY);
     select();
+#ifdef LINUX_ARCH_RASPBERRYPI
+    char data[66 /* max payload len */ + 1];
+    data[0] = REG_FIFO & 0x7F;
+    SPI.transfern(data, 3);
+    PAYLOADLEN = data[1];
+    TARGETID = data[2];
+#else
     SPI.transfer(REG_FIFO & 0x7F);
     PAYLOADLEN = SPI.transfer(0);
-    PAYLOADLEN = PAYLOADLEN > 66 ? 66 : PAYLOADLEN; // precaution
     TARGETID = SPI.transfer(0);
+#endif
+    PAYLOADLEN = PAYLOADLEN > 66 ? 66 : PAYLOADLEN; // precaution
     if(!(_promiscuousMode || TARGETID == _address || TARGETID == RF69_BROADCAST_ADDR) // match this node's address, or broadcast address or anything in promiscuous mode
        || PAYLOADLEN < 3) // address situation could receive packets that are malformed and don't fit this libraries extra fields
     {
@@ -366,8 +388,15 @@ void RFM69::interruptHandler() {
     }
 
     DATALEN = PAYLOADLEN - 3;
+#ifdef LINUX_ARCH_RASPBERRYPI
+    data[0] = REG_FIFO & 0x77;
+    SPI.transfern(data, DATALEN + 3);
+    SENDERID = data[1];
+    uint8_t CTLbyte = data[2];
+#else
     SENDERID = SPI.transfer(0);
     uint8_t CTLbyte = SPI.transfer(0);
+#endif
 
     ACK_RECEIVED = CTLbyte & RFM69_CTL_SENDACK; // extract ACK-received flag
     ACK_REQUESTED = CTLbyte & RFM69_CTL_REQACK; // extract ACK-requested flag
@@ -376,7 +405,11 @@ void RFM69::interruptHandler() {
 
     for (uint8_t i = 0; i < DATALEN; i++)
     {
+#ifdef LINUX_ARCH_RASPBERRYPI
+      DATA[i] = data[i + 3];
+#else
       DATA[i] = SPI.transfer(0);
+#endif
     }
     if (DATALEN < RF69_MAX_DATA_LEN) {
       DATA[DATALEN] = 0; // add null at end of string
@@ -435,10 +468,19 @@ void RFM69::encrypt(const char* key) {
   if (key != 0)
   {
     select();
+#ifdef LINUX_ARCH_RASPBERRYPI
+    char data[17];
+    data[0] = REG_AESKEY1 | 0x80;
+    for (uint8_t i = 0; i < 16; i++) {
+      data[i + 1] = key[i];
+    }
+    SPI.transfern(data, 17);
+#else
     SPI.transfer(REG_AESKEY1 | 0x80);
     for (uint8_t i = 0; i < 16; i++) {
       SPI.transfer(key[i]);
     }
+#endif
     unselect();
   }
   writeReg(REG_PACKETCONFIG2, (readReg(REG_PACKETCONFIG2) & 0xFE) | (key ? 1 : 0));
@@ -461,8 +503,14 @@ int16_t RFM69::readRSSI(bool forceTrigger) {
 uint8_t RFM69::readReg(uint8_t addr)
 {
   select();
+#ifdef LINUX_ARCH_RASPBERRYPI
+  char data[2] = { (char)(addr & 0x7F), 0 };
+  SPI.transfern(data, 2);
+  uint8_t regval = data[1];
+#else
   SPI.transfer(addr & 0x7F);
   uint8_t regval = SPI.transfer(0);
+#endif
   unselect();
   return regval;
 }
@@ -470,8 +518,13 @@ uint8_t RFM69::readReg(uint8_t addr)
 void RFM69::writeReg(uint8_t addr, uint8_t value)
 {
   select();
+#ifdef LINUX_ARCH_RASPBERRYPI
+  char data[2] = { (char)(addr | 0x80), value };
+  SPI.transfern(data, 2);
+#else
   SPI.transfer(addr | 0x80);
   SPI.transfer(value);
+#endif
   unselect();
 }
 
@@ -486,7 +539,11 @@ void RFM69::select() {
   // set RFM69 SPI settings
   SPI.setDataMode(SPI_MODE0);
   SPI.setBitOrder(MSBFIRST);
+#ifdef LINUX_ARCH_RASPBERRYPI
+  SPI.setClockDivider(SPI_CLOCK_DIV64);
+#else
   SPI.setClockDivider(SPI_CLOCK_DIV4); // decided to slow down from DIV2 after SPI stalling in some instances, especially visible on mega1284p when RFM69 and FLASH chip both present
+#endif
   hwDigitalWrite(_slaveSelectPin, LOW);
 }
 
@@ -567,10 +624,7 @@ void RFM69::readAllRegs()
   Serial.println("Address - HEX - BIN");
   for (uint8_t regAddr = 1; regAddr <= 0x4F; regAddr++)
   {
-    select();
-    SPI.transfer(regAddr & 0x7F); // send address + r/w bit
-    regVal = SPI.transfer(0);
-    unselect();
+    regVal = readReg(regAddr);
 
     Serial.print(regAddr, HEX);
     Serial.print(" - ");

--- a/drivers/RFM69/RFM69.h
+++ b/drivers/RFM69/RFM69.h
@@ -117,7 +117,7 @@ class RFM69 {
     void setCS(uint8_t newSPISlaveSelect); //!< setCS
     int16_t readRSSI(bool forceTrigger=false); //!< readRSSI
     void promiscuous(bool onOff=true); //!< promiscuous
-    virtual void setHighPower(bool onOFF=true); //!< setHighPower (have to call it after initialize for RFM69HW)
+    virtual void setHighPower(bool onOFF=true); //!< setHighPower (has to be called after initialize() for RFM69HW)
     virtual void setPowerLevel(uint8_t level); //!< setPowerLevel (reduce/increase transmit power level)
     void sleep(); //!< sleep
     uint8_t readTemperature(uint8_t calFactor=0); //!< readTemperature (get CMOS temperature (8bit))
@@ -132,6 +132,7 @@ class RFM69 {
     static void isr0(); //!< isr0
     void virtual interruptHandler(); //!< interruptHandler
     virtual void interruptHook(uint8_t CTLbyte); //!< interruptHook
+    static volatile bool _inISR; //!< _inISR
     virtual void sendFrame(uint8_t toAddress, const void* buffer, uint8_t size, bool requestACK=false, bool sendACK=false); //!< sendFrame
 
     static RFM69* selfPointer; //!< selfPointer
@@ -152,6 +153,7 @@ class RFM69 {
     virtual void setHighPowerRegs(bool onOff); //!< setHighPowerRegs
     virtual void select(); //!< select
     virtual void unselect(); //!< unselect
+    inline void maybeInterrupts(); //!< maybeInterrupts
 };
 
 #endif

--- a/drivers/RPi/rpi_util.h
+++ b/drivers/RPi/rpi_util.h
@@ -45,10 +45,10 @@ typedef enum {
 } rpi_pinedge;
 
 typedef enum {
-	PIN_SPI_SS = RPI_GPIO_P1_24,
-	PIN_SPI_MOSI = RPI_GPIO_P1_19,
-	PIN_SPI_MISO = RPI_GPIO_P1_21,
-	PIN_SPI_SCK = RPI_GPIO_P1_23
+	PIN_SPI_SS = 24,
+	PIN_SPI_MOSI = 19,
+	PIN_SPI_MISO = 21,
+	PIN_SPI_SCK = 23
 } rpi_spipins;
 
 const uint8_t SS   = PIN_SPI_SS;


### PR DESCRIPTION
Apart from fixes (commit 2+3) these commits make a directly attached HopeRF RFM69 module to a Raspberry Pi work.

Since linux is a time-sharing system the Raspberry Pi might loose interrupts or packets because of unfavorable scheduling. However I've been using this since quite some time and unless the system is highly overloaded my system will at least catch the 2nd (out of 3) retries. In general I don't encounter packet loss.

I'm running this on a RPi 1 so I haven't tested multicore behavior. In general the usage of `volatile` in SMP environments and multi-threaded applications (interrupt handler) can cause troubles.
