### PR TITLE
RPi: Improve build process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ stino.settings
 MyPrivateConfig.h
 Documentation/html
 doxygen_sqlite3.db
+Makefile.inc
+build
+bin

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,10 @@
 #
 # Makefile for MySensors
 #
+#  
+# The arduino library build part were inspired by
+#   Arduino-Makefile project, Copyright (C) 2012 Sudar <http://sudarmuthu.com>
+#
 # Description:
 # ------------
 # use make all and make install to install the gateway
@@ -11,42 +15,92 @@ CONFIG_FILE=Makefile.inc
 
 include $(CONFIG_FILE)
 
-GATEWAY_BIN=mysGateway
-GATEWAY=examples_linux/$(GATEWAY_BIN)
+CPPFLAGS+=-Ofast -g -Wall -Wextra
+DEPFLAGS=-MT $@ -MMD -MP
+
+GATEWAY_BIN=mysgw
+GATEWAY=$(BINDIR)/$(GATEWAY_BIN)
 GATEWAY_C_SOURCES=$(wildcard drivers/Linux/*.c)
-GATEWAY_CPP_SOURCES=$(wildcard drivers/Linux/*.cpp) examples_linux/mysGateway.cpp
-OBJECTS=$(patsubst %.c,%.o,$(GATEWAY_C_SOURCES)) $(patsubst %.cpp,%.o,$(GATEWAY_CPP_SOURCES))
+GATEWAY_CPP_SOURCES=$(wildcard drivers/Linux/*.cpp) examples_linux/mysgw.cpp
+GATEWAY_OBJECTS=$(patsubst %.c,$(BUILDDIR)/%.o,$(GATEWAY_C_SOURCES)) $(patsubst %.cpp,$(BUILDDIR)/%.o,$(GATEWAY_CPP_SOURCES))
 
-DEPS+=$(patsubst %.c,%.d,$(GATEWAY_C_SOURCES)) $(patsubst %.cpp,%.d,$(GATEWAY_CPP_SOURCES))
-
-CINCLUDE=-I. -I./core -I./drivers/Linux
+INCLUDES=-I. -I./core -I./drivers/Linux
 
 ifeq ($(SOC),$(filter $(SOC),BCM2835 BCM2836))
 RPI_C_SOURCES=$(wildcard drivers/RPi/*.c)
 RPI_CPP_SOURCES=$(wildcard drivers/RPi/*.cpp)
-OBJECTS+=$(patsubst %.c,%.o,$(RPI_C_SOURCES)) $(patsubst %.cpp,%.o,$(RPI_CPP_SOURCES))
+GATEWAY_OBJECTS+=$(patsubst %.c,$(BUILDDIR)/%.o,$(RPI_C_SOURCES)) $(patsubst %.cpp,$(BUILDDIR)/%.o,$(RPI_CPP_SOURCES))
 
-DEPS+=$(patsubst %.c,%.d,$(RPI_C_SOURCES)) $(patsubst %.cpp,%.d,$(RPI_CPP_SOURCES))
-
-CINCLUDE+=-I./drivers/RPi
+INCLUDES+=-I./drivers/RPi
 endif
 
-.PHONY: all gateway cleanconfig clean install uninstall force
+# Gets include flags for library
+get_library_includes = $(if $(and $(wildcard $(1)/src), $(wildcard $(1)/library.properties)), \
+							-I$(1)/src, \
+							$(addprefix -I,$(1) $(wildcard $(1)/utility)))
 
-all: $(GATEWAY)
+# Gets all sources with given extension (param2) for library (path = param1)
+# for old (1.0.x) layout looks in . and "utility" directories
+# for new (1.5.x) layout looks in src and recursively its subdirectories
+get_library_files  = $(if $(and $(wildcard $(1)/src), $(wildcard $(1)/library.properties)), \
+						$(call rwildcard,$(1)/src/,*.$(2)), \
+						$(wildcard $(1)/*.$(2) $(1)/utility/*.$(2)))
+
+ifdef ARDUINO_LIB_DIR
+ARDUINO=arduino
+ARDUINO_LIBS:=$(shell find $(ARDUINO_LIB_DIR) -mindepth 1 -maxdepth 1 -type d)
+ARDUINO_INCLUDES:=$(foreach lib, $(ARDUINO_LIBS), $(call get_library_includes,$(lib)))
+ARDUINO_LIB_CPP_SRCS:=$(foreach lib, $(ARDUINO_LIBS), $(call get_library_files,$(lib),cpp))
+ARDUINO_LIB_C_SRCS:=$(foreach lib, $(ARDUINO_LIBS), $(call get_library_files,$(lib),c))
+ARDUINO_LIB_AS_SRCS:=$(foreach lib, $(ARDUINO_LIBS), $(call get_library_files,$(lib),S))
+ARDUINO_LIB_OBJS=$(patsubst $(ARDUINO_LIB_DIR)/%.cpp,$(BUILDDIR)/arduinolibs/%.cpp.o,$(ARDUINO_LIB_CPP_SRCS)) \
+				$(patsubst $(ARDUINO_LIB_DIR)/%.c,$(BUILDDIR)/arduinolibs/%.c.o,$(ARDUINO_LIB_C_SRCS)) \
+				$(patsubst $(ARDUINO_LIB_DIR)/%.S,$(BUILDDIR)/arduinolibs/%.S.o,$(ARDUINO_LIB_AS_SRCS))
+
+INCLUDES+=$(ARDUINO_INCLUDES)
+DEPS+=$(ARDUINO_LIB_OBJS:.o=.d)
+endif
+
+DEPS+=$(GATEWAY_OBJECTS:.o=.d)
+
+.PHONY: all createdir cleanconfig clean install uninstall
+
+all: createdir $(ARDUINO) $(GATEWAY)
+
+createdir:
+	@mkdir -p $(BUILDDIR) $(BINDIR)
+
+# Arduino libraries Build
+$(ARDUINO): CPPFLAGS+=-DARDUINO=100
+$(ARDUINO): $(ARDUINO_LIB_OBJS)
+	@printf "[Done building Arduino Libraries]\n"
 
 # Gateway Build
-$(GATEWAY): $(OBJECTS)
-	$(CXX) $(LDFLAGS) -o $@ $(OBJECTS)
+$(GATEWAY): $(GATEWAY_OBJECTS) $(ARDUINO_LIB_OBJS)
+	$(CXX) $(LDFLAGS) -o $@ $(GATEWAY_OBJECTS) $(ARDUINO_LIB_OBJS)
 
 # Include all .d files
 -include $(DEPS)
 
-%.o: %.cpp
-	$(CXX) $(CXXFLAGS) $(CINCLUDE) -MMD -c -o $@ $<
+$(BUILDDIR)/arduinolibs/%.cpp.o: $(ARDUINO_LIB_DIR)/%.cpp
+	@mkdir -p $(dir $@)
+	$(CXX) $(DEPFLAGS) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c $< -o $@
 
-%.o: %.c
-	$(CC) $(CFLAGS) $(CINCLUDE) -MMD -c -o $@ $<
+$(BUILDDIR)/arduinolibs/%.c.o: $(ARDUINO_LIB_DIR)/%.c
+	@mkdir -p $(dir $@)
+	$(CC) $(DEPFLAGS) $(CPPFLAGS) $(CFLAGS) $(INCLUDES) -c $< -o $@
+
+$(BUILDDIR)/arduinolibs/%.S.o: $(ARDUINO_LIB_DIR)/%.S
+	@mkdir -p $(dir $@)
+	$(CC) $(DEPFLAGS) $(CPPFLAGS) $(ASFLAGS) $(INCLUDES) -c $< -o $@
+
+$(BUILDDIR)/%.o: %.cpp
+	@mkdir -p $(dir $@)
+	$(CXX) $(DEPFLAGS) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c $< -o $@
+
+$(BUILDDIR)/%.o: %.c
+	@mkdir -p $(dir $@)
+	$(CC) $(DEPFLAGS) $(CPPFLAGS) $(CFLAGS) $(INCLUDES) -c $< -o $@
 
 # clear configuration files
 cleanconfig:
@@ -56,7 +110,7 @@ cleanconfig:
 # clear build files
 clean:
 	@echo "[Cleaning]"
-	rm -rf build $(OBJECTS) $(GATEWAY) $(DEPS)
+	rm -rf $(BUILDDIR) $(BINDIR)
 
 $(CONFIG_FILE):
 	@echo "[Running configure]"
@@ -70,31 +124,31 @@ install-gateway:
 
 install-initscripts:
 ifeq ($(INIT_SYSTEM), systemd)
-	install -m0644 initscripts/mysgateway.systemd /etc/systemd/system/mysgateway.service
-	@sed -i -e "s|%gateway_dir%|${GATEWAY_DIR}|g" /etc/systemd/system/mysgateway.service
+	install -m0644 initscripts/mysgw.systemd /etc/systemd/system/mysgw.service
+	@sed -i -e "s|%gateway_dir%|${GATEWAY_DIR}|g" /etc/systemd/system/mysgw.service
 	systemctl daemon-reload
 	@echo "MySensors gateway has been installed, to add to the boot run:"
-	@echo "  sudo systemctl enable mysgateway.service"
+	@echo "  sudo systemctl enable mysgw.service"
 	@echo "To start the gateway run:"
-	@echo "  sudo systemctl start mysgateway.service"
+	@echo "  sudo systemctl start mysgw.service"
 else ifeq ($(INIT_SYSTEM), sysvinit)
-	install -m0755 initscripts/mysgateway.sysvinit /etc/init.d/mysgateway
-	@sed -i -e "s|%gateway_dir%|${GATEWAY_DIR}|g" /etc/init.d/mysgateway
+	install -m0755 initscripts/mysgw.sysvinit /etc/init.d/mysgw
+	@sed -i -e "s|%gateway_dir%|${GATEWAY_DIR}|g" /etc/init.d/mysgw
 	@echo "MySensors gateway has been installed, to add to the boot run:"
-	@echo "  sudo update-rc.d mysgateway defaults"
+	@echo "  sudo update-rc.d mysgw defaults"
 	@echo "To start the gateway run:"
-	@echo "  sudo service mysgateway start"
+	@echo "  sudo service mysgw start"
 endif
 
 uninstall:
 ifeq ($(INIT_SYSTEM), systemd)
-	@echo "Stopping daemon mysgateway (ignore errors)"
-	-@systemctl stop mysgateway.service
+	@echo "Stopping daemon mysgw (ignore errors)"
+	-@systemctl stop mysgw.service
 	@echo "removing files"
-	rm /etc/systemd/system/mysgateway.service $(GATEWAY_DIR)/$(GATEWAY_BIN)
+	rm /etc/systemd/system/mysgw.service $(GATEWAY_DIR)/$(GATEWAY_BIN)
 else ifeq ($(INIT_SYSTEM), sysvinit)
-	@echo "Stopping daemon mysgateway (ignore errors)"
-	-@service mysgateway stop
+	@echo "Stopping daemon mysgw (ignore errors)"
+	-@service mysgw stop
 	@echo "removing files"
-	rm /etc/init.d/mysgateway $(GATEWAY_DIR)/$(GATEWAY_BIN)
+	rm /etc/init.d/mysgw $(GATEWAY_DIR)/$(GATEWAY_BIN)
 endif

--- a/configure
+++ b/configure
@@ -14,10 +14,15 @@ Help:
 Building options:
     --soc=[BCM2835|BCM2836|AM33XX|A10|A13|A20|H3]
                                 SoC type to be used. [configure autodetected]
-    --cpu-flags=<CXXFLAGS>      CPU defining/optimizing flags to be used. [configure autodetected]
-    --extra-cxxflags=<CXXFLAGS> Extra C flags passed to C/C++ compilation. []
+    --cpu-flags=<CPUFLAGS>      CPU defining/optimizing flags to be used. [configure autodetected]
+    --extra-cflags=<CFLAGS>     Extra C flags passed to C compilation. []
+    --extra-cxxflags=<CXXFLAGS> Extra C++ flags passed to C++ compilation. []
     --extra-ldflags=<LDFLAGS>   Extra C flags passed to linking. []
+    --c_compiler=<CC>           C compiler. [arm-linux-gnueabihf-gcc][gcc]
     --cxx_compiler=<CXX>        C++ compiler [arm-linux-gnueabihf-g++][g++]
+    --build-dir=<DIR>           Compiler directory to store object files. [build]
+    --bin-dir=<DIR>             Compiler directory to store binary files. [bin]
+    --arduino-lib-dir=<DIR>     Arduino library directory.
     --no-clean                  Don't clean previous build artifacts.
 
 Installation options:
@@ -175,10 +180,10 @@ function gcc_cpu_flags {
     local soc=$1
     case $soc in
     BCM2835)
-        flags="-march=armv6zk -mtune=arm1176jzf-s -mfpu=vfp -mfloat-abi=hard -DLINUX_ARCH_RASPBERRYPI"
+        flags="-march=armv6zk -mtune=arm1176jzf-s -mfpu=vfp -mfloat-abi=hard"
         ;;
     BCM2836)
-        flags="-march=armv7-a -mtune=cortex-a7 -mfpu=neon-vfpv4 -mfloat-abi=hard -DLINUX_ARCH_RASPBERRYPI"
+        flags="-march=armv7-a -mtune=cortex-a7 -mfpu=neon-vfpv4 -mfloat-abi=hard"
         ;;
     AM33XX)
         flags="-march=armv7-a -mtune=cortex-a8 -mfpu=neon -mfloat-abi=hard"
@@ -206,7 +211,7 @@ debug=enable
 gateway_type=ethernet
 transport_type=nrf24
 
-params="SOC CXXFLAGS LDFLAGS PREFIX CXX GATEWAY_DIR INIT_SYSTEM"
+params="SOC CFLAGS CXXFLAGS CPPFLAGS LDFLAGS PREFIX CC CXX ARDUINO_LIB_DIR BUILDDIR BINDIR GATEWAY_DIR INIT_SYSTEM"
 
 for opt do
     if [ "$opt" = "-h" ] || [ "$opt" = "--help" ]; then
@@ -221,14 +226,29 @@ for opt do
     --cpu-flags=*)
         CPUFLAGS="$optarg"
         ;;
+    --extra-cflags=*)
+        CFLAGS="$optarg"
+        ;;
     --extra-cxxflags=*)
         CXXFLAGS="$optarg"
         ;;
     --extra-ldflags=*)
         LDFLAGS="$optarg"
         ;;
+    --c_compiler=*)
+        CC="$optarg"
+        ;;
     --cxx_compiler=*)
         CXX="$optarg"
+        ;;
+    --arduino-lib-dir=*)
+        ARDUINO_LIB_DIR=$optarg
+        ;;
+    --build-dir=*)
+        BUILDDIR="$optarg"
+        ;;
+    --bin-dir=*)
+        BINDIR="$optarg"
         ;;
     --no-clean*)
         NO_CLEAN="1"
@@ -247,10 +267,10 @@ for opt do
         ;;
     --my-node-id=*)
         gateway_type="none";
-        CXXFLAGS="-DMY_NODE_ID=${optarg} $CXXFLAGS"
+        CPPFLAGS="-DMY_NODE_ID=${optarg} $CPPFLAGS"
         ;;
     --my-config-file=*)
-        CXXFLAGS="-DMY_LINUX_CONFIG_FILE=\\\"${optarg}\\\" $CXXFLAGS"
+        CPPFLAGS="-DMY_LINUX_CONFIG_FILE=\\\"${optarg}\\\" $CPPFLAGS"
         ;;
     --my-transport=*)
         transport_type=${optarg}
@@ -260,74 +280,74 @@ for opt do
         transport_type=${optarg}
         ;;
     --my-serial-port=*)
-        CXXFLAGS="-DMY_LINUX_SERIAL_PORT=\\\"${optarg}\\\" $CXXFLAGS"
+        CPPFLAGS="-DMY_LINUX_SERIAL_PORT=\\\"${optarg}\\\" $CPPFLAGS"
         ;;
     --my-serial-baudrate=*)
-        CXXFLAGS="-DMY_BAUD_RATE=${optarg} $CXXFLAGS"
+        CPPFLAGS="-DMY_BAUD_RATE=${optarg} $CPPFLAGS"
         ;;
     --my-serial-is-pty*)
-        CXXFLAGS="-DMY_IS_SERIAL_PTY $CXXFLAGS"
+        CPPFLAGS="-DMY_IS_SERIAL_PTY $CPPFLAGS"
         ;;
     --my-serial-pty=*)
-        CXXFLAGS="-DMY_LINUX_SERIAL_PTY=\\\"${optarg}\\\" $CXXFLAGS"
+        CPPFLAGS="-DMY_LINUX_SERIAL_PTY=\\\"${optarg}\\\" $CPPFLAGS"
         ;;
     --my-serial-groupname=*)
-        CXXFLAGS="-DMY_LINUX_SERIAL_GROUPNAME=\\\"${optarg}\\\" $CXXFLAGS"
+        CPPFLAGS="-DMY_LINUX_SERIAL_GROUPNAME=\\\"${optarg}\\\" $CPPFLAGS"
         ;;
     --my-rf24-channel=*)
-        CXXFLAGS="-DMY_RF24_CHANNEL=${optarg} $CXXFLAGS"
+        CPPFLAGS="-DMY_RF24_CHANNEL=${optarg} $CPPFLAGS"
         ;;
     --my-rf24-pa-level=*)
-        CXXFLAGS="-DMY_RF24_PA_LEVEL=${optarg} $CXXFLAGS"
+        CPPFLAGS="-DMY_RF24_PA_LEVEL=${optarg} $CPPFLAGS"
         ;;
     --my-controller-url-address=*)
-        CXXFLAGS="-DMY_CONTROLLER_URL_ADDRESS=\\\"${optarg}\\\" $CXXFLAGS"
+        CPPFLAGS="-DMY_CONTROLLER_URL_ADDRESS=\\\"${optarg}\\\" $CPPFLAGS"
         ;;
     --my-controller-ip-address=*)
         controller_ip=`echo ${optarg//./,}`
-        CXXFLAGS="-DMY_CONTROLLER_IP_ADDRESS=${controller_ip} $CXXFLAGS"
+        CPPFLAGS="-DMY_CONTROLLER_IP_ADDRESS=${controller_ip} $CPPFLAGS"
         ;;
     --my-port=*)
-        CXXFLAGS="-DMY_PORT=${optarg} $CXXFLAGS"
+        CPPFLAGS="-DMY_PORT=${optarg} $CPPFLAGS"
         ;;
     --my-mqtt-client-id=*)
-        CXXFLAGS="-DMY_MQTT_CLIENT_ID=\\\"${optarg}\\\" $CXXFLAGS"
+        CPPFLAGS="-DMY_MQTT_CLIENT_ID=\\\"${optarg}\\\" $CPPFLAGS"
         ;;
     --my-mqtt-publish-topic-prefix=*)
-        CXXFLAGS="-DMY_MQTT_PUBLISH_TOPIC_PREFIX=\\\"${optarg}\\\" $CXXFLAGS"
+        CPPFLAGS="-DMY_MQTT_PUBLISH_TOPIC_PREFIX=\\\"${optarg}\\\" $CPPFLAGS"
         ;;
     --my-mqtt-subscribe-topic-prefix=*)
-        CXXFLAGS="-DMY_MQTT_SUBSCRIBE_TOPIC_PREFIX=\\\"${optarg}\\\" $CXXFLAGS"
+        CPPFLAGS="-DMY_MQTT_SUBSCRIBE_TOPIC_PREFIX=\\\"${optarg}\\\" $CPPFLAGS"
         ;;
     --my-rf24-irq-pin=*)
-        CXXFLAGS="-DMY_RX_MESSAGE_BUFFER_FEATURE -DMY_RF24_IRQ_PIN=${optarg} $CXXFLAGS"
+        CPPFLAGS="-DMY_RX_MESSAGE_BUFFER_FEATURE -DMY_RF24_IRQ_PIN=${optarg} $CPPFLAGS"
         ;;
     --my-rx-message-buffer-size=*)
-        CXXFLAGS="-DMY_RX_MESSAGE_BUFFER_SIZE=${optarg} $CXXFLAGS"
+        CPPFLAGS="-DMY_RX_MESSAGE_BUFFER_SIZE=${optarg} $CPPFLAGS"
         ;;
     --my-rs485-serial-port=*)
-        CXXFLAGS="-DMY_RS485_HWSERIAL=\\\"${optarg}\\\" $CXXFLAGS"
+        CPPFLAGS="-DMY_RS485_HWSERIAL=\\\"${optarg}\\\" $CPPFLAGS"
         ;;
     --my-rs485-baudrate=*)
-        CXXFLAGS="-DMY_RS485_BAUD_RATE=${optarg} $CXXFLAGS"
+        CPPFLAGS="-DMY_RS485_BAUD_RATE=${optarg} $CPPFLAGS"
         ;;
     --my-rs485-de-pin=*)
-        CXXFLAGS="-DMY_RS485_DE_PIN=${optarg} $CXXFLAGS"
+        CPPFLAGS="-DMY_RS485_DE_PIN=${optarg} $CPPFLAGS"
         ;;
     --my-rs485-max-msg-length=*)
-        CXXFLAGS="-DMY_RS485_MAX_MESSAGE_LENGTH=${optarg} $CXXFLAGS"
+        CPPFLAGS="-DMY_RS485_MAX_MESSAGE_LENGTH=${optarg} $CPPFLAGS"
         ;;
     --my-leds-err-pin=*)
-        CXXFLAGS="-DMY_DEFAULT_ERR_LED_PIN=${optarg} $CXXFLAGS"
+        CPPFLAGS="-DMY_DEFAULT_ERR_LED_PIN=${optarg} $CPPFLAGS"
         ;;
     --my-leds-rx-pin=*)
-        CXXFLAGS="-DMY_DEFAULT_RX_LED_PIN=${optarg} $CXXFLAGS"
+        CPPFLAGS="-DMY_DEFAULT_RX_LED_PIN=${optarg} $CPPFLAGS"
         ;;
     --my-leds-tx-pin=*)
-        CXXFLAGS="-DMY_DEFAULT_TX_LED_PIN=${optarg} $CXXFLAGS"
+        CPPFLAGS="-DMY_DEFAULT_TX_LED_PIN=${optarg} $CPPFLAGS"
         ;;
     --my-leds-blinking-inverse*)
-        CXXFLAGS="-DMY_WITH_LEDS_BLINKING_INVERSE $CXXFLAGS"
+        CPPFLAGS="-DMY_WITH_LEDS_BLINKING_INVERSE $CPPFLAGS"
         ;;
     *)
         echo "[WARNING] Unknown option detected:$opt, ignored"
@@ -336,7 +356,10 @@ for opt do
 done
 
 PREFIX=${PREFIX:-/usr/local}
+BUILDDIR=${BUILDDIR:-build}
+BINDIR=${BINDIR:-bin}
 GATEWAY_DIR=${GATEWAY_DIR:-${PREFIX}/bin}
+CC=${CC:-gcc}
 CXX=${CXX:-g++}
 
 if [ -z "${SOC}" ]; then
@@ -353,32 +376,34 @@ if [ -z "${CPUFLAGS}" ]; then
     CPUFLAGS=$(gcc_cpu_flags $SOC)
 fi
 
-CXXFLAGS="$CPUFLAGS -Ofast -g -Wall -Wextra $CXXFLAGS"
-CFLAGS="-Ofast -g -Wall -Wextra $CFLAGS"
+if [[ $SOC == "BCM2835" || $SOC == "BCM2836" ]]; then
+    CPPFLAGS="-DLINUX_ARCH_RASPBERRYPI $CPPFLAGS"
+fi
 
 if [[ $TYPE == "RPi2" || $TYPE == "RPi3" || $REV == "0010" ]]; then
-    CXXFLAGS+="-D__RPI_BPLUS"
+    CPPFLAGS="-D__RPI_BPLUS $CPPFLAGS"
 fi
 
 if [[ ${debug} == "enable" ]]; then
-    CXXFLAGS="-DMY_DEBUG $CXXFLAGS"
+    CPPFLAGS="-DMY_DEBUG $CPPFLAGS"
 fi
 
 if [[ ${gateway_type} == "ethernet" ]]; then
-    CXXFLAGS="-DMY_GATEWAY_LINUX $CXXFLAGS"
+    CPPFLAGS="-DMY_GATEWAY_LINUX $CPPFLAGS"
 elif [[ ${gateway_type} == "serial" ]]; then
-    CXXFLAGS="-DMY_GATEWAY_SERIAL $CXXFLAGS"
+    CPPFLAGS="-DMY_GATEWAY_SERIAL $CPPFLAGS"
 elif [[ ${gateway_type} == "mqtt" ]]; then
-    CXXFLAGS="-DMY_GATEWAY_LINUX -DMY_GATEWAY_MQTT_CLIENT $CXXFLAGS"
+    CPPFLAGS="-DMY_GATEWAY_LINUX -DMY_GATEWAY_MQTT_CLIENT $CPPFLAGS"
 fi
 
 if [[ ${transport_type} == "nrf24" ]]; then
-    CXXFLAGS="-DMY_RADIO_NRF24 $CXXFLAGS"
+    CPPFLAGS="-DMY_RADIO_NRF24 $CPPFLAGS"
 elif [[ ${transport_type} == "rs485" ]]; then
-    CXXFLAGS="-DMY_RS485 $CXXFLAGS"
+    CPPFLAGS="-DMY_RS485 $CPPFLAGS"
 fi
 
 LDFLAGS="-pthread $LDFLAGS"
+CPPFLAGS="$CPUFLAGS $CPPFLAGS"
 
 if [ -x /usr/bin/systemctl ] || [ -x /bin/systemctl ]; then
     INIT_SYSTEM=systemd

--- a/core/MyHwLinuxGeneric.cpp
+++ b/core/MyHwLinuxGeneric.cpp
@@ -5,8 +5,8 @@
  * repeater and gateway builds a routing tables in EEPROM which keeps track of the
  * network topology allowing messages to be routed to nodes.
  *
- * Created by Marcelo Aquino <marceloaqno@gmail.org>
- * Copyright (C) 2016 Marcelo Aquino
+ * Created by Henrik Ekblad <henrik.ekblad@mysensors.org>
+ * Copyright (C) 2013-2016 Sensnology AB
  * Full contributor list: https://github.com/mysensors/MySensors/graphs/contributors
  *
  * Documentation: http://www.mysensors.org

--- a/core/MyHwLinuxGeneric.h
+++ b/core/MyHwLinuxGeneric.h
@@ -5,8 +5,8 @@
  * repeater and gateway builds a routing tables in EEPROM which keeps track of the
  * network topology allowing messages to be routed to nodes.
  *
- * Created by Marcelo Aquino <marceloaqno@gmail.org>
- * Copyright (C) 2016 Marcelo Aquino
+ * Created by Henrik Ekblad <henrik.ekblad@mysensors.org>
+ * Copyright (C) 2013-2016 Sensnology AB
  * Full contributor list: https://github.com/mysensors/MySensors/graphs/contributors
  *
  * Documentation: http://www.mysensors.org

--- a/core/MyHwRPi.cpp
+++ b/core/MyHwRPi.cpp
@@ -5,8 +5,8 @@
  * repeater and gateway builds a routing tables in EEPROM which keeps track of the
  * network topology allowing messages to be routed to nodes.
  *
- * Created by Marcelo Aquino <marceloaqno@gmail.org>
- * Copyright (C) 2016 Marcelo Aquino
+ * Created by Henrik Ekblad <henrik.ekblad@mysensors.org>
+ * Copyright (C) 2013-2016 Sensnology AB
  * Full contributor list: https://github.com/mysensors/MySensors/graphs/contributors
  *
  * Documentation: http://www.mysensors.org
@@ -22,17 +22,11 @@
 #include <stdarg.h>
 #include <time.h>
 #include "SoftEeprom.h"
-#include "log.h"
 
 static SoftEeprom eeprom = SoftEeprom(MY_LINUX_CONFIG_FILE, 1024);	// ATMega328 has 1024 bytes
 
 void hwInit()
 {
-	if (!bcm2835_init()) {
-		logError("Failed to initialized bcm2835.\n");
-		exit(1);
-	}
-
 #ifdef MY_GATEWAY_SERIAL
 	MY_SERIALDEVICE.begin(MY_BAUD_RATE);
 	#ifdef MY_LINUX_SERIAL_GROUPNAME

--- a/core/MyHwRPi.h
+++ b/core/MyHwRPi.h
@@ -5,8 +5,8 @@
  * repeater and gateway builds a routing tables in EEPROM which keeps track of the
  * network topology allowing messages to be routed to nodes.
  *
- * Created by Marcelo Aquino <marceloaqno@gmail.org>
- * Copyright (C) 2016 Marcelo Aquino
+ * Created by Henrik Ekblad <henrik.ekblad@mysensors.org>
+ * Copyright (C) 2013-2016 Sensnology AB
  * Full contributor list: https://github.com/mysensors/MySensors/graphs/contributors
  *
  * Documentation: http://www.mysensors.org
@@ -20,7 +20,24 @@
 #ifndef MyHwRPi_h
 #define MyHwRPi_h
 
+#include <stdlib.h>
 #include "MyHwLinuxGeneric.h"
+#include "log.h"
+#include "bcm2835.h"
+
+class Bcm2835Init {
+public:
+	Bcm2835Init() {
+		if (!bcm2835_init()) {
+			logError("Failed to initialized bcm2835.\n");
+			exit(1);
+		}
+	}
+	~Bcm2835Init() {
+		bcm2835_close();
+	}
+};
+Bcm2835Init bcm2835Init;
 
 #undef hwDigitalWrite
 inline void hwDigitalWrite(uint8_t, uint8_t);

--- a/core/MyMainLinux.cpp
+++ b/core/MyMainLinux.cpp
@@ -102,7 +102,7 @@ static int daemonize(void)
 
 void print_usage()
 {
-	printf("Usage: mysGateway [options]\n\n" \
+	printf("Usage: mysgw [options]\n\n" \
 			 "Options:\n" \
 			 "  -h, --help                 Display a short summary of all program options.\n" \
 			 "  -d, --debug                Enable debug.\n" \
@@ -154,7 +154,7 @@ void generate_soft_sign_hmac_key()
 
 	print_soft_sign_hmac_key(key);
 
-	printf("To use this key, run mysGateway with:\n"
+	printf("To use this key, run mysgw with:\n"
 			" --set-soft-hmac-key=");
 	for (int i = 0; i < 32; i++) {
 		printf("%02X", key[i]);
@@ -226,7 +226,7 @@ void generate_soft_sign_serial_key()
 
 	print_soft_sign_serial_key(key);
 
-	printf("To use this key, run mysGateway with:\n"
+	printf("To use this key, run mysgw with:\n"
 			" --set-soft-serial-key=");
 	for (int i = 0; i < 9; i++) {
 		printf("%02X", key[i]);
@@ -298,7 +298,7 @@ void generate_aes_key()
 
 	print_aes_key(key);
 
-	printf("To use this key, run mysGateway with:\n"
+	printf("To use this key, run mysgw with:\n"
 			" --set-aes-key=");
 	for (int i = 0; i < 16; i++) {
 		printf("%02X", key[i]);

--- a/drivers/Linux/Arduino.h
+++ b/drivers/Linux/Arduino.h
@@ -68,6 +68,7 @@ using std::abs;
 typedef bool boolean;
 typedef uint8_t byte;
 typedef string String;
+typedef char __FlashStringHelper;
 
 void yield(void);
 unsigned long millis(void);

--- a/drivers/RPi/rpi_util.h
+++ b/drivers/RPi/rpi_util.h
@@ -45,10 +45,10 @@ typedef enum {
 } rpi_pinedge;
 
 typedef enum {
-	PIN_SPI_SS = RPI_GPIO_P1_24,
-	PIN_SPI_MOSI = RPI_GPIO_P1_19,
-	PIN_SPI_MISO = RPI_GPIO_P1_21,
-	PIN_SPI_SCK = RPI_GPIO_P1_23
+	PIN_SPI_SS = 24,
+	PIN_SPI_MOSI = 19,
+	PIN_SPI_MISO = 21,
+	PIN_SPI_SCK = 23
 } rpi_spipins;
 
 const uint8_t SS   = PIN_SPI_SS;

--- a/examples_linux/mysgw.cpp
+++ b/examples_linux/mysgw.cpp
@@ -5,8 +5,8 @@
  * repeater and gateway builds a routing tables in EEPROM which keeps track of the
  * network topology allowing messages to be routed to nodes.
  *
- * Created by Marcelo Aquino <marceloaqno@gmail.org>
- * Copyleft (c) 2016, Marcelo Aquino
+ * Created by Henrik Ekblad <henrik.ekblad@mysensors.org>
+ * Copyright (C) 2013-2016 Sensnology AB
  * Full contributor list: https://github.com/mysensors/Arduino/graphs/contributors
  *
  * Documentation: http://www.mysensors.org
@@ -67,15 +67,25 @@
 // Note: MY_SIGNING_REQUEST_SIGNATURES must also be set
 //#define MY_SIGNING_GW_REQUEST_SIGNATURES_FROM_ALL
 
+// Enables RF24 encryption (all nodes and gateway must have this enabled, and all must be
+// personalized with the same AES key)
+//#define MY_RF24_ENABLE_ENCRYPTION
+
 #include <MySensors.h>
 
-void setup() { 
+#define ARDUINO 100
+// This space is intended to be used to include arduino libraries
+
+#undef ARDUINO
+
+void setup() {
+	// Setup locally attached sensors
 }
 
 void presentation() {
-  // Present locally attached sensors here    
+	// Present locally attached sensors here    
 }
 
 void loop() {
-  // Send locally attached sensors data here
+	// Send locally attached sensors data here
 }

--- a/initscripts/mysgw.systemd
+++ b/initscripts/mysgw.systemd
@@ -3,7 +3,7 @@ Description=MySensors Gateway daemon
 Requires=network.target
 
 [Service]
-ExecStart=%gateway_dir%/mysGateway
+ExecStart=%gateway_dir%/mysgw
 
 [Install]
 WantedBy=multi-user.target

--- a/initscripts/mysgw.sysvinit
+++ b/initscripts/mysgw.sysvinit
@@ -1,6 +1,6 @@
 #! /bin/sh
 ### BEGIN INIT INFO
-# Provides:          mysGateway
+# Provides:          mysgw
 # Required-Start:    $remote_fs $syslog
 # Required-Stop:     $remote_fs $syslog
 # Default-Start:     2 3 4 5
@@ -15,7 +15,7 @@
 # PATH should only include /usr/* if it runs after the mountnfs.sh script
 PATH=/sbin:/usr/sbin:/bin:/usr/bin:/usr/local/sbin:/usr/local/bin
 DESC="MySensors Gateway"
-NAME=mysGateway
+NAME=mysgw
 DAEMON=%gateway_dir%/$NAME
 DAEMON_ARGS="-b"
 PIDFILE=/var/run/$NAME.pid


### PR DESCRIPTION
Add option to set an external arduino libraries directory. All libraries
from this folder will be compile and available for use in the gateway.
Some Arduino libraries can be used on Linux/RPI with none/minor adjustments,
but there are some that will have to be completely rewritten.

The build process uses a separate folder for objects and binary files
which can be set by the user.

Initialize the bcm2835 inside a class constructor to fix cases where pin
operations are used before hwInit().

Fix SPI pins default values.

Fix activation interrupt functions.

Fix some headers.

Rename gateway binary and services to mysgw.