### PR TITLE
Update the pre-commit git hook

### DIFF
--- a/hooks/install-hooks.sh
+++ b/hooks/install-hooks.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+PRECOMMIT=hooks/pre-commit
+GITROOT=$(git rev-parse --git-dir)
+if [[ "$OSTYPE" == "linux-gnu" ]]; then
+	rm -f $GITROOT/$PRECOMMIT
+	ln -s ../../$PRECOMMIT.sh $GITROOT/$PRECOMMIT
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+	rm -f $GITROOT/$PRECOMMIT
+	ln -s ../../$PRECOMMIT.sh $GITROOT/$PRECOMMIT
+elif [[ "$OSTYPE" == "cygwin" ]]; then
+	rm -f $GITROOT/$PRECOMMIT
+	cp $GITROOT/../$PRECOMMIT.sh $GITROOT/$PRECOMMIT
+elif [[ "$OSTYPE" == "msys" ]]; then
+	rm -f $GITROOT/$PRECOMMIT
+	cp $GITROOT/../$PRECOMMIT.sh $GITROOT/$PRECOMMIT
+elif [[ "$OSTYPE" == "freebsd"* ]]; then
+	rm -f $GITROOT/$PRECOMMIT
+	ln -s ../../$PRECOMMIT.sh $GITROOT/$PRECOMMIT
+else
+	echo "Unknown/unsupported OS, won't install anything"
+fi

--- a/hooks/pre-commit.sh
+++ b/hooks/pre-commit.sh
@@ -1,27 +1,57 @@
 #!/bin/sh
+if git rev-parse --verify HEAD >/dev/null 2>&1
+then
+	against=HEAD
+else
+	# Initial commit: diff against an empty tree object
+	against=4b825dc642cb6eb9a060e54bf8d69288fbee4904
+fi
 
-OPTIONS="--options=.astylerc"
+OPTIONS="--options=.astylerc -n"
+CPPCHECK_OPTIONS="--quiet --error-exitcode=1 --force --enable=style,information --library=avr --platform=tools/cppcheck/avr.xml --includes-file=tools/cppcheck/includes.cfg --suppressions-list=tools/cppcheck/suppressions.cfg"
+FILES=$(git diff-index  --cached $against | grep -E '[MA]	.*\.(c|cpp|h|hpp|ino)$' | cut -d'	' -f 2)
 
 RETURN=0
-ASTYLE=astyle
+ASTYLE=$(which astyle >/dev/null)
 if [ $? -ne 0 ]; then
-	echo "[!] astyle not installed or not in current path. Unable to check source file format policy." >&2
-	exit 1
-fi
+	echo "astyle not installed or not in current path. Unable to check source file format policy. Make sure you have a clean commit, or the CI system will reject your pull request." >&2
+else
+	ASTYLE=astyle
+	for FILE in $FILES; do
+		$ASTYLE $OPTIONS $FILE >/dev/null
+		$(git diff-files --quiet $FILE) >&2
+		if [ $? -ne 0 ]; then
+			echo "[!] $FILE has been updated to match the MySensors core coding style." >&2
+			RETURN=1
+		fi
+	done
 
-FILES=`git diff --name-only --diff-filter=ACMR | grep -E "\.(c|cpp|h|ino)$"`
-for FILE in $FILES; do
-	$ASTYLE $OPTIONS < $FILE | cmp -s $FILE -
-	if [ $? -ne 0 ]; then
-		echo "[!] $FILE does not respect the agreed coding style." >&2
-		RETURN=1
+	if [ $RETURN -ne 0 ]; then
+		echo "" >&2
+		echo "Styling updates applied. Review the changes and use 'git add' to update your staged data." >&2
+		exit $RETURN
 	fi
-done
-
-if [ $RETURN -eq 1 ]; then
-	echo "" >&2
-	echo "Make sure you have run astyle with the following options:" >&2
-	echo $OPTIONS >&2
 fi
 
+RETURN=0
+CPPCHECK=$(which cppcheck >/dev/null)
+if [ $? -ne 0 ]; then
+	echo "cppcheck not installed or not in current path. Unable to do static code analysis. Make sure you have a clean commit, or the CI system will reject your pull request." >&2
+else
+	CPPCHECK=cppcheck
+	for FILE in $FILES; do
+		$CPPCHECK $CPPCHECK_OPTIONS $FILE 2>&1
+		if [ $? -eq 1 ]; then
+			echo "[!] $FILE has coding issues." >&2
+			RETURN=1
+		fi
+	done
+
+	if [ $RETURN -ne 0 ]; then
+		echo "" >&2
+		echo "Make sure you have run cppcheck 1.76.1 or newer cleanly with the following options:" >&2
+		echo $CPPCHECK $CPPCHECK_OPTIONS $FILES >&2
+		exit 1
+	fi
+fi
 exit $RETURN

--- a/tools/cppcheck/suppressions.cfg
+++ b/tools/cppcheck/suppressions.cfg
@@ -1,3 +1,5 @@
 toomanyconfigs
 missingInclude
+missingIncludeSystem
 ConfigurationNotChecked
+unmatchedSuppression


### PR DESCRIPTION
It now supports both Linux and Windows and checks
both coding style (astyle) and does static code
analysis (cppcheck).
Tested using "Bash on Ubuntu on Windows" and the
git shell (via GitHub for Windows).

Installation for Linux users:
ln -s ../../hooks/pre-commit.sh .git/hooks/pre-commit

Installation for Windows users:
cp hooks/pre-commit.sh .git/hooks/pre-commit

Tools:
astyle (2.05.1 or newer)
cppcheck (1.76.1 or newer)