### PR TITLE
Allow cppcheck library option override

### DIFF
--- a/.mystools/.bundle_runtime.sh
+++ b/.mystools/.bundle_runtime.sh
@@ -24,7 +24,7 @@ tools_dir()
 	git_config_tools_dir='git config mysensors.toolsdir'
 
 	# Set mysensors.toolsdir in git config if it hasn't been set
-	if [ ! $($git_config_tools_dir) -o ! -d $($git_config_tools_dir) ]; then
+	if [[ ! $($git_config_tools_dir) || ! -d "$($git_config_tools_dir)" ]]; then
 		$git_config_tools_dir "$( cd "$(dirname "${BASH_SOURCE[0]}")"; git rev-parse --show-prefix )"
 		git config alias.mystoolspath '![ -z "${GIT_PREFIX}" ] || cd ${GIT_PREFIX}; echo $(git rev-parse --show-cdup)$(git config mysensors.toolsdir)'
 	fi
@@ -86,7 +86,7 @@ runBundle()
 #
 $(git rev-parse --is-inside-work-tree --quiet >/dev/null 2>&1) || err "Working directory is not a git repository.  aborting..."
 
-if environment_outdated && [[ $(basename "${0}") != *bootstrap* ]]; then
+if [[ $(basename "${0}") != *bootstrap* ]] && environment_outdated ; then
 	err "Your environment is out of date...  Re-run $(git mystoolspath)bootstrap-dev.sh and try again"
 fi
 

--- a/.mystools/cppcheck/config/unix32.xml
+++ b/.mystools/cppcheck/config/unix32.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<platform>
+  <char_bit>8</char_bit>
+  <default-sign>unsigned</default-sign>
+  <sizeof>
+    <short>2</short>
+    <int>4</int>
+    <long>4</long>
+    <long-long>8</long-long>
+    <float>4</float>
+    <double>8</double>
+    <long-double>12</long-double>
+    <pointer>4</pointer>
+    <size_t>4</size_t>
+    <wchar_t>2</wchar_t>
+  </sizeof>
+</platform>

--- a/.mystools/cppcheck/options.sh
+++ b/.mystools/cppcheck/options.sh
@@ -4,8 +4,8 @@ OPTIONS="--quiet                                      \
 	--error-exitcode=1                                  \
 	--force                                             \
 	--enable=style,information                          \
-	--library=avr                                       \
-	--platform="${TOOLCONFIG}"/avr.xml                  \
+	--library=${LIBRARY:-avr}                           \
+	--platform="${TOOLCONFIG}"/${PLATFORM:-avr.xml}     \
  	--includes-file="${TOOLCONFIG}"/includes.cfg	      \
 	--suppressions-list="${TOOLCONFIG}"/suppressions.cfg"
 


### PR DESCRIPTION
 * Using LIBRARY=avr|gnu git cppcheck ... will set the command
   line library= to the value
 * Corrected logical if error when bootstapping a pristine repo

References #672