### PR TITLE
Fixed issue with Soft Signing on ESP8266

### DIFF
--- a/core/MyHwESP8266.cpp
+++ b/core/MyHwESP8266.cpp
@@ -109,10 +109,10 @@ uint16_t hwCPUVoltage()
 #else
 uint16_t hwCPUVoltage()
 {
-    // when soft signing is active, the internal voltage
-    // cannot be measured. Therefore the return value of
-    // this function is always 0.
-    return 0;
+	// when soft signing is active, the internal voltage
+	// cannot be measured. Therefore the return value of
+	// this function is always 0.
+	return 0;
 }
 #endif
 

--- a/core/MyHwESP8266.cpp
+++ b/core/MyHwESP8266.cpp
@@ -91,6 +91,14 @@ int8_t hwSleep(uint8_t interrupt1, uint8_t mode1, uint8_t interrupt2, uint8_t mo
 }
 
 #if defined(MY_DEBUG) || defined(MY_SPECIAL_DEBUG)
+
+// The ESP8266 has only one analog input. When soft signing
+// is used, this port has to be made available to generate
+// the nonce for the message signing. When the ADC mode is
+// set to measure the internal voltage, the analogRead()
+// on the would always return 65535, which is not as random
+// as it is required.
+#if !defined(MY_SIGNING_SOFT)
 ADC_MODE(ADC_VCC);
 
 uint16_t hwCPUVoltage()
@@ -98,6 +106,15 @@ uint16_t hwCPUVoltage()
 	// in mV
 	return ESP.getVcc();
 }
+#else
+uint16_t hwCPUVoltage()
+{
+    // when soft signing is active, the internal voltage
+    // cannot be measured. Therefore the return value of
+    // this function is always 0.
+    return 0;
+}
+#endif
 
 uint16_t hwCPUFrequency()
 {


### PR DESCRIPTION
I figured out, when you like to use soft signing on the ESP8266 it doesn't work when the _MY_DEBUG_ flag is defined. In this case the only available analog input _A0_ is occupied to measure the internal voltage. In this case an analogRead(A0) would always produce 65535. Since the soft signing has to generate a nonce to do message signing, this wouldn't generate the random numbers as it is required to do a secure message signing. I've added an additional check, which doesn't switch the ADC mode in case soft signing is active. The downside is, that in this case the function _hwCPUVoltage_ would always return 0, since we cannot measure the internal voltage and read the analog input A0 at the same time. 
For details have a look at the nodemcu documentation: https://nodemcu.readthedocs.io/en/dev/en/modules/adc/

On the current MySensors release 2.0 the issue is even worse, the ADC mode switch is done, without checking the flag _MY_DEBUG_.