### PR TITLE
ESP8266: Use RNG for randomSeed()

### DIFF
--- a/core/MyHwESP8266.cpp
+++ b/core/MyHwESP8266.cpp
@@ -90,13 +90,25 @@ int8_t hwSleep(uint8_t interrupt1, uint8_t mode1, uint8_t interrupt2, uint8_t mo
 	return MY_SLEEP_NOT_POSSIBLE;
 }
 
-#if defined(MY_DEBUG) || defined(MY_SPECIAL_DEBUG)
+#if defined(MY_SPECIAL_DEBUG)
+// settings for getVcc()
 ADC_MODE(ADC_VCC);
+#else
+// [default] settings for analogRead(A0) 
+ADC_MODE(ADC_TOUT);
+#endif
+
+#if defined(MY_DEBUG) || defined(MY_SPECIAL_DEBUG)
 
 uint16_t hwCPUVoltage()
 {
-	// in mV
+#if defined(MY_SPECIAL_DEBUG)
+	// in mV, requires ADC_VCC set
 	return ESP.getVcc();
+#else
+	// not possible
+	return 0;
+#endif
 }
 
 uint16_t hwCPUFrequency()

--- a/core/MyHwESP8266.h
+++ b/core/MyHwESP8266.h
@@ -32,7 +32,6 @@
 
 #define EEPROM_size (1024)
 
-
 // Define these as macros to save valuable space
 #define hwDigitalWrite(__pin, __value) digitalWrite(__pin, __value)
 #define hwDigitalRead(__pin) digitalRead(__pin)
@@ -40,7 +39,7 @@
 #define hwWatchdogReset() wdt_reset()
 #define hwReboot() ESP.restart()
 #define hwMillis() millis()
-#define hwRandomNumberInit() randomSeed(analogRead(MY_SIGNING_SOFT_RANDOMSEED_PIN))
+#define hwRandomNumberInit() randomSeed(RANDOM_REG32)
 
 void hwInit(void);
 void hwReadConfigBlock(void* buf, void* adr, size_t length);


### PR DESCRIPTION
- use ESP8266 RNG in hwRandomNumberInit()
- _ADC_TOUT_ is set by default, _ADC_VCC_ if `MY_SPECIAL_DEBUG` enabled