### PR TITLE
Use local ID functions, fix regression

### DIFF
--- a/MyConfig.h
+++ b/MyConfig.h
@@ -103,7 +103,7 @@
 * @brief Interval to dump content of routing table to eeprom
 */
 #ifndef MY_ROUTING_TABLE_SAVE_INTERVAL_MS
-#define MY_ROUTING_TABLE_SAVE_INTERVAL_MS	(10*60*1000ul)
+#define MY_ROUTING_TABLE_SAVE_INTERVAL_MS	(30*60*1000ul)
 #endif
 /**
 * @def MY_TRANSPORT_SANITY_CHECK
@@ -114,17 +114,17 @@
 
 /**
 * @def MY_TRANSPORT_SANITY_CHECK_INTERVAL_MS
-* @brief Interval (in ms) of transport sanity checks
+* @brief Interval (in ms) for transport sanity checks
 */
 #ifndef MY_TRANSPORT_SANITY_CHECK_INTERVAL_MS
-#define MY_TRANSPORT_SANITY_CHECK_INTERVAL_MS (60*1000ul)
+#define MY_TRANSPORT_SANITY_CHECK_INTERVAL_MS (15*60*1000ul)
 #endif
 /**
 * @def MY_TRANSPORT_DISCOVERY_INTERVAL_MS
 * @brief This is a gateway-only feature: Interval (in ms) to issue network discovery checks
 */
 #ifndef MY_TRANSPORT_DISCOVERY_INTERVAL_MS
-#define MY_TRANSPORT_DISCOVERY_INTERVAL_MS (10*60*1000ul)
+#define MY_TRANSPORT_DISCOVERY_INTERVAL_MS (20*60*1000ul)
 #endif
 
 /**

--- a/MySensors.h
+++ b/MySensors.h
@@ -239,6 +239,11 @@ MY_DEFAULT_RX_LED_PIN in your sketch instead to enable LEDs
 #endif
 #endif
 
+#if defined(MY_REPEATER_FEATURE)
+#define MY_TRANSPORT_SANITY_CHECK
+#endif
+
+
 #if defined(MY_TRANSPORT_DONT_CARE_MODE)
 #error This directive is deprecated, set MY_TRANSPORT_WAIT_READY_MS instead!
 #endif

--- a/core/MySensorsCore.cpp
+++ b/core/MySensorsCore.cpp
@@ -40,9 +40,7 @@ void _callbackTransportReady(void)
 {
 	if (!_coreConfig.presentationSent) {
 		presentNode();
-#if !defined(MY_GATEWAY_FEATURE)
 		_registerNode();
-#endif
 		_coreConfig.presentationSent = true;
 	}
 }
@@ -153,6 +151,8 @@ void _begin(void)
 #if defined(MY_SENSOR_NETWORK)
 	CORE_DEBUG(PSTR("MCO:BGN:INIT OK,TSP=%d\n"), isTransportReady());
 #else
+	// no sensor network defined, call presentation & registration
+	_callbackTransportReady();
 	CORE_DEBUG(PSTR("MCO:BGN:INIT OK,TSP=NA\n"));
 #endif
 	// reset wdt before handing over to loop

--- a/core/MyTransport.cpp
+++ b/core/MyTransport.cpp
@@ -625,13 +625,13 @@ void transportProcessMessage(void)
 	// update routing table if msg not from parent
 #if defined(MY_REPEATER_FEATURE)
 #if !defined(MY_GATEWAY_FEATURE)
-	if (last != getParentNodeId()) {
+	if (last != _transportConfig.parentNodeId) {
 #else
 	// GW doesn't have parent
 	{
 #endif
 		// Message is from one of the child nodes and not sent from this node. Add it to routing table.
-		if (sender != getNodeId())
+		if (sender != _transportConfig.nodeId)
 		{
 			transportSetRoute(sender, last);
 		}
@@ -840,10 +840,10 @@ void transportProcessMessage(void)
 void transportInvokeSanityCheck(void)
 {
 	if (!transportSanityCheck()) {
-		TRANSPORT_DEBUG(PSTR("!TSF:SNK:FAIL\n"));	// sanity check fail
+		TRANSPORT_DEBUG(PSTR("!TSF:SAN:FAIL\n"));	// sanity check fail
 		transportSwitchSM(stFailure);
 	} else {
-		TRANSPORT_DEBUG(PSTR("TSF:SNK:OK\n"));		// sanity check ok
+		TRANSPORT_DEBUG(PSTR("TSF:SAN:OK\n"));		// sanity check ok
 	}
 }
 

--- a/core/MyTransport.h
+++ b/core/MyTransport.h
@@ -38,17 +38,17 @@
 *   - TSM:READY					from <b>stReady</b> Transport is ready and fully operational
 *   - TSM:FAIL						from <b>stFailure</b> Failure in transport link or transport HW
 *  - Transport support function (<b>TSF</b>)
-*   - TSF:CHKUPL					from @ref transportCheckUplink(), checks connection to GW
-*   - TSF:ASID						from @ref transportAssignNodeID(), assigns node ID
-*   - TSF:PING						from @ref transportPingNode(), pings a node
+*   - TSF:CKU						from @ref transportCheckUplink(), checks connection to GW
+*   - TSF:SID						from @ref transportAssignNodeID(), assigns node ID
+*   - TSF:PNG						from @ref transportPingNode(), pings a node
 *   - TSF:WUR						from @ref transportWaitUntilReady(), waits until transport is ready
 *   - TSF:CRT						from @ref transportClearRoutingTable(), clears routing table stored in EEPROM
 *   - TSF:LRT						from @ref transportLoadRoutingTable(), loads RAM routing table from EEPROM (only GW/repeaters)
 *   - TSF:SRT						from @ref transportSaveRoutingTable(), saves RAM routing table to EEPROM (only GW/repeaters)
 *   - TSF:MSG						from @ref transportProcessMessage(), processes incoming message
-*   - TSF:SANCHK					from @ref transportInvokeSanityCheck(), calls transport-specific sanity check
-*   - TSF:ROUTE					from @ref transportRouteMessage(), sends message
-*   - TSF:SEND						from @ref transportSendRoute(), sends message if transport is ready (exposed)
+*   - TSF:SAN						from @ref transportInvokeSanityCheck(), calls transport-specific sanity check
+*   - TSF:RTE						from @ref transportRouteMessage(), sends message
+*   - TSF:SND						from @ref transportSendRoute(), sends message if transport is ready (exposed)
 
 *
 * Transport debug log messages:
@@ -80,13 +80,13 @@
 * | | TSM	| FAIL		| CNT=%%d				| <b>Transition to stFailure state</b>, consecutive failure counter (CNT)
 * | | TSM	| FAIL		| PDT					| Power-down transport
 * | | TSM	| FAIL		| RE-INIT				| Attempt to re-initialize transport
-* | | TSF	| CHKUPL	| OK					| Uplink OK
-* | | TSF	| CHKUPL	| OK,FCTRL				| Uplink OK, flood control prevents pinging GW in too short intervals
-* | | TSF	| CHKUPL	| DGWC,O=%%d,N=%%d		| Uplink check revealed changed network topology, old distance (O), new distance (N)
-* | | TSF	| CHKUPL	| FAIL					| No reply received when checking uplink
-* | | TSF	| ASID		| OK,ID=%%d				| Node ID assigned
-* |!| TSF	| ASID		| FAIL,ID=%%d			| Assigned ID is invalid
-* | | TSF	| PING		| SEND,TO=%%d			| Send ping to destination (TO)
+* | | TSF	| CKU		| OK					| Uplink OK
+* | | TSF	| CKU		| OK,FCTRL				| Uplink OK, flood control prevents pinging GW in too short intervals
+* | | TSF	| CKU		| DGWC,O=%%d,N=%%d		| Uplink check revealed changed network topology, old distance (O), new distance (N)
+* | | TSF	| CKU		| FAIL					| No reply received when checking uplink
+* | | TSF	| SID		| OK,ID=%%d				| Node ID assigned
+* |!| TSF	| SID		| FAIL,ID=%%d			| Assigned ID is invalid
+* | | TSF	| PNG		| SEND,TO=%%d			| Send ping to destination (TO)
 * | | TSF	| WUR		| MS=%%lu				| Wait until transport ready, timeout (MS)
 * | | TSF	| MSG		| ACK REQ				| ACK message requested
 * | | TSF	| MSG		| ACK					| ACK message, do not proceed but forward to callback
@@ -108,14 +108,14 @@
 * |!| TSF	| MSG		| REL MSG,NORP			| Node received a message for relaying, but node is not a repeater, message skipped
 * |!| TSF	| MSG		| SIGN FAIL				| Signing message failed
 * |!| TSF	| MSG		| GWL FAIL				| GW uplink failed
-* | | TSF	| SANCHK	| OK					| Sanity check passed
-* |!| TSF	| SANCHK	| FAIL					| Sanity check failed, attempt to re-initialize radio
+* | | TSF	| SAN		| OK					| Sanity check passed
+* |!| TSF	| SAN		| FAIL					| Sanity check failed, attempt to re-initialize radio
 * | | TSF	| CRT		| OK					| Clearing routing table successful
 * | | TSF	| LRT		| OK					| Loading routing table successful
 * | | TSF	| SRT		| OK					| Saving routing table successful
-* |!| TSF	| ROUTE		| FPAR ACTIVE			| Finding parent active, message not sent
-* |!| TSF	| ROUTE		| DST %%d UNKNOWN		| Routing for destination (DST) unknown, send message to parent
-* |!| TSF	| SEND		| TNR					| Transport not ready, message cannot be sent
+* |!| TSF	| RTE		| FPAR ACTIVE			| Finding parent active, message not sent
+* |!| TSF	| RTE		| DST %%d UNKNOWN		| Routing for destination (DST) unknown, send message to parent
+* |!| TSF	| SND		| TNR					| Transport not ready, message cannot be sent
 *
 * Incoming / outgoing messages:
 *


### PR DESCRIPTION
- Use local functions: transportGetNodeId() and transportGetParentNodeId()
- Fix regression: _registerNode() call
- GW w/o radio: call presentation/registration functions upon init=ok
- Adjust debug log messages
- Adjust NWD / SAN / SRT timings