### PR TITLE
Reduce memory footprint: -200 bytes

### DIFF
--- a/drivers/ATSHA204/sha256.cpp
+++ b/drivers/ATSHA204/sha256.cpp
@@ -34,13 +34,16 @@ const uint8_t sha256InitState[] PROGMEM = {
 
 Sha256Class::Sha256Class()
 {
+	/*
 	memset(keyBuffer, 0, BLOCK_LENGTH);
 	memset(innerHash, 0, HASH_LENGTH);
 	memset(buffer.b, 0, BLOCK_LENGTH);
 	memset(state.b, 0, BLOCK_LENGTH);
 	bufferOffset = 0;
 	byteCount = 0;
+	*/
 }
+
 
 void Sha256Class::init(void)
 {


### PR DESCRIPTION
- Constructor/variable init. added due to Cppcheck result, this occupies 200 bytes of RAM even if class not used
