### PR TITLE
OTA: Add incoming FW block check

### DIFF
--- a/core/MyIndication.h
+++ b/core/MyIndication.h
@@ -44,6 +44,7 @@ typedef enum {
 	INDICATION_WAKEUP,                        //!< Node just woke from sleep.
 	INDICATION_FW_UPDATE_START,               //!< Start of OTA firmware update process.
 	INDICATION_FW_UPDATE_RX,                  //!< Received a piece of firmware data.
+	INDICATION_FW_UPDATE_RX_ERR,              //!< Received wrong piece of firmware data.
 
 	INDICATION_ERR_START = 100,
 	INDICATION_ERR_TX,                        //!< Failed to transmit message.

--- a/core/MyOTAFirmwareUpdate.h
+++ b/core/MyOTAFirmwareUpdate.h
@@ -40,6 +40,7 @@
 * |!| OTA  | FWP	| FLASH INIT FAIL							| Failed to initialise flash
 * | | OTA  | FWP	| UPDATE SKIPPED							| FW update skipped, no newer version available
 * | | OTA  | FWP	| RECV B=%04X								| Received FW block (B)
+* |!| OTA  | FWP	| WRONG FWB									| Wrong FW block received
 * | | OTA  | FWP	| FW END									| FW received, proceed to CRC verification
 * | | OTA  | FWP	| CRC OK									| FW CRC verification OK
 * |!| OTA  | FWP	| CRC FAIL									| FW CRC verification failed

--- a/drivers/SPIFlash/SPIFlash.cpp
+++ b/drivers/SPIFlash/SPIFlash.cpp
@@ -60,7 +60,7 @@ void SPIFlash::select()
 #ifndef SPI_HAS_TRANSACTION
 	noInterrupts();
 #endif
-#ifndef ESP8266
+#if defined(SPCR) && defined(SPSR)
 	_SPCR = SPCR;
 	_SPSR = SPSR;
 #endif
@@ -88,7 +88,7 @@ void SPIFlash::unselect()
 #else
 	interrupts();
 #endif
-#ifndef ESP8266
+#if defined(SPCR) && defined(SPSR)
 	SPCR = _SPCR;
 	SPSR = _SPSR;
 #endif
@@ -97,7 +97,7 @@ void SPIFlash::unselect()
 /// setup SPI, read device ID etc...
 boolean SPIFlash::initialize()
 {
-#ifndef ESP8266
+#if defined(SPCR) && defined(SPSR)
 	_SPCR = SPCR;
 	_SPSR = SPSR;
 #endif

--- a/tests/Arduino/sketches/ota_firmware_update_nrf24/ota_firmware_update_nrf24.ino
+++ b/tests/Arduino/sketches/ota_firmware_update_nrf24/ota_firmware_update_nrf24.ino
@@ -1,0 +1,26 @@
+/*
+ * The MySensors Arduino library handles the wireless radio link and protocol
+ * between your home built sensors/actuators and HA controller of choice.
+ * The sensors forms a self healing radio network with optional repeaters. Each
+ * repeater and gateway builds a routing tables in EEPROM which keeps track of the
+ * network topology allowing messages to be routed to nodes.
+ *
+ * Created by Henrik Ekblad <henrik.ekblad@mysensors.org>
+ * Copyright (C) 2013-2015 Sensnology AB
+ * Full contributor list: https://github.com/mysensors/Arduino/graphs/contributors
+ *
+ * Documentation: http://www.mysensors.org
+ * Support Forum: http://forum.mysensors.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ *******************************
+ */
+#include <stdint.h>
+#include <pins_arduino.h>
+#define MY_DEBUG
+#define MY_RADIO_NRF24
+#define MY_OTA_FIRMWARE_FEATURE
+#include <MySensors.h>


### PR DESCRIPTION
This fixes the OTA FW block mismatch issue:

https://forum.mysensors.org/topic/5686/strange-behavior-of-rfm69-ota-burning-firmware-after-some-research

- add OTA test skript