### PR TITLE
Fix compile errors in PingPongSensor example for ESP8266

### DIFF
--- a/examples/PingPongSensor/PingPongSensor.ino
+++ b/examples/PingPongSensor/PingPongSensor.ino
@@ -84,7 +84,7 @@ void sendPingOrPongResponse( MyMessage msg )
 	    nodeTypeAsCharRepresentation(msg.sender));
 
 	// Set payload to current time in millis to ensure each message is unique
-	response.set( millis() );
+	response.set( (uint32_t)millis() );
 	response.setDestination(msg.sender);
 	send(response);
 }
@@ -92,7 +92,7 @@ void sendPingOrPongResponse( MyMessage msg )
 void setNodeId(byte nodeID)
 {
 	LOG(F("Setting node id to: %i.\n***Please restart the node for changes to take effect.\n"), nodeID);
-	eeprom_write_byte((uint8_t*)EEPROM_NODE_ID_ADDRESS, (byte)nodeID);
+	hwWriteConfig(EEPROM_NODE_ID_ADDRESS, (byte)nodeID);
 }
 
 const char * msgTypeAsCharRepresentation( mysensor_data mType )


### PR DESCRIPTION
Without this fix, the example does not compile in Arduino IDE.
The following errors were presented:
PingPongSensor.ino: In function 'void sendPingOrPongResponse(MyMessage)':
PingPongSensor:87: error: call of overloaded 'set(long unsigned int)' is ambiguous
  response.set( millis() );
and
PingPongSensor.ino: In function 'void setNodeId(byte)':
PingPongSensor:95: error: 'eeprom_write_byte' was not declared in this scope
  eeprom_write_byte((uint8_t*)EEPROM_NODE_ID_ADDRESS, (byte)nodeID);

The code compiles fine for Nano with and without this change.

The problem was reported by lozzer65 in
https://forum.mysensors.org/topic/5710/first-sensor-project-steep-learning-curve/