### PR TITLE
Enable RPi gateway wth RFM69

### DIFF
--- a/MyConfig.h
+++ b/MyConfig.h
@@ -680,6 +680,14 @@
 #endif
 #endif
 
+/**
+ * @def MY_RF69_SPI_CLOCK_DIV
+ * @brief RF69 SPI Clock divider pin number.
+ */
+#ifndef MY_RF69_SPI_CLOCK_DIV
+#define MY_RF69_SPI_CLOCK_DIV RF69_SPI_CLOCK_DIV
+#endif
+
 // Enables RFM69 encryption (all nodes and gateway must have this enabled, and all must be personalized with the same AES key)
 //#define MY_RFM69_ENABLE_ENCRYPTION
 

--- a/MySensors.h
+++ b/MySensors.h
@@ -65,6 +65,8 @@
 #include "core/MyHwATMega328.cpp"
 #elif defined(ARDUINO_ARCH_SAMD)
 #include "core/MyHwSAMD.cpp"
+#elif defined(ARDUINO_ARCH_STM32F1)
+#include "core/MyHwSTM32F1.cpp"
 #elif defined(__linux__)
 #ifdef LINUX_ARCH_RASPBERRYPI
 #include "core/MyHwRPi.cpp"
@@ -342,6 +344,8 @@ MY_DEFAULT_RX_LED_PIN in your sketch instead to enable LEDs
 #if !defined(MY_CORE_ONLY)
 #if defined(ARDUINO_ARCH_ESP8266)
 #include "core/MyMainESP8266.cpp"
+#elif defined(ARDUINO_ARCH_STM32F1)
+#include "core/MyMainSTM32F1.cpp"
 #elif defined(__linux__)
 #include "core/MyMainLinux.cpp"
 #else

--- a/configure
+++ b/configure
@@ -53,7 +53,7 @@ MySensors options:
                                 MQTT publish topic prefix.
     --my-mqtt-subscribe-topic-prefix=<PREFIX>
                                 MQTT subscribe topic prefix.
-    --my-transport=[none|nrf24|rs485|rfm95]
+    --my-transport=[none|nrf24|rs485|rfm95|rfm69]
                                 Transport type, set to none to disable transport feature. [nrf24]
     --my-rf24-channel=<0-125>   RF channel for the sensor net, 0-125. [76]
     --my-rf24-pa-level=[RF24_PA_MAX|RF24_PA_LOW]
@@ -63,6 +63,13 @@ MySensors options:
                                 Enables RF24 encryption.
                                 All nodes and gateway must have this enabled, and all must be
                                 personalized with the same AES key
+    --my-rfm69-frequency=[315|433|868|915]
+                                RFM69 Module Frequency
+    --my-is-rfm69hw             Enable high-powered rfm69hw
+    --my-rf69-irq-pin=<PIN>     Pin number connected to RFM69 IRQ pin.
+    --my-rf69-spi-cs=<PIN>      Pin number to use for RFM69 Chip-Select
+    --my-rf69-spi-clock-div=<0-65536>
+                                Clock divider to use for RFM69
     --my-rx-message-buffer-size=<SIZE>
                                 Buffer size for incoming messages when using rf24 interrupts. [20]
     --my-rs485-serial-port=<PORT>
@@ -322,6 +329,31 @@ for opt do
     --my-rf24-pa-level=*)
         CPPFLAGS="-DMY_RF24_PA_LEVEL=${optarg} $CPPFLAGS"
         ;;
+    --my-rf69-irq-pin=*)
+        CPPFLAGS="-DMY_RF69_IRQ_PIN=${optarg} $CPPFLAGS"
+        ;;
+    --my-rf69-spi-cs=*)
+        CPPFLAGS="-DMY_RF69_SPI_CS=${optarg} $CPPFLAGS"
+        ;;
+    --my-rf69-spi-clock-div=*)
+        CPPFLAGS="-DMY_RF69_SPI_CLOCK_DIV=${optarg} $CPPFLAGS"
+        ;;
+    --my-is-rfm69hw*)
+        CPPFLAGS="-DMY_IS_RFM69HW $CPPFLAGS"
+        ;;
+    --my-rfm69-frequency=*)
+        if [[ ${optarg} == "315" ]]; then
+            CPPFLAGS="-DMY_RFM69_FREQUENCY=RF69_315MHZ $CPPFLAGS"
+        elif [[ ${optarg} == "433" ]]; then
+            CPPFLAGS="-DMY_RFM69_FREQUENCY=RF69_433MHZ $CPPFLAGS"
+        elif [[ ${optarg} == "868" ]]; then
+            CPPFLAGS="-DMY_RFM69_FREQUENCY=RF69_868MHZ $CPPFLAGS"
+        elif [[ ${optarg} == "915" ]]; then
+            CPPFLAGS="-DMY_RFM69_FREQUENCY=RF69_915MHZ $CPPFLAGS"
+        else
+            echo "[WARNING] Illegal value for --my-rfm69-frequency=${optarg}, ignored"
+        fi
+        ;;
     --my-controller-url-address=*)
         CPPFLAGS="-DMY_CONTROLLER_URL_ADDRESS=\\\"${optarg}\\\" $CPPFLAGS"
         ;;
@@ -445,6 +477,8 @@ elif [[ ${transport_type} == "rs485" ]]; then
     CPPFLAGS="-DMY_RS485 $CPPFLAGS"
 elif [[ ${transport_type} == "rfm95" ]]; then
     CPPFLAGS="-DMY_RADIO_RFM95 $CPPFLAGS"
+elif [[ ${transport_type} == "rfm69" ]]; then
+    CPPFLAGS="-DMY_RADIO_RFM69 $CPPFLAGS"
 else
     echo "Invalid transport type."
     echo "Aborting."

--- a/core/MyHwSTM32F1.cpp
+++ b/core/MyHwSTM32F1.cpp
@@ -1,0 +1,147 @@
+/**
+ * The MySensors Arduino library handles the wireless radio link and protocol
+ * between your home built sensors/actuators and HA controller of choice.
+ * The sensors forms a self healing radio network with optional repeaters. Each
+ * repeater and gateway builds a routing tables in EEPROM which keeps track of the
+ * network topology allowing messages to be routed to nodes.
+ *
+ * Created by Henrik Ekblad <henrik.ekblad@mysensors.org>
+ * Copyright (C) 2013-2015 Sensnology AB
+ * Full contributor list: https://github.com/mysensors/Arduino/graphs/contributors
+ *
+ * Documentation: http://www.mysensors.org
+ * Support Forum: http://forum.mysensors.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ */
+
+#ifdef ARDUINO_ARCH_STM32F1
+
+#include "MyHwSTM32F1.h"
+#include <EEPROM.h>
+
+	
+void hwInit(void)
+{
+#ifdef MY_RF69_IRQ_PIN
+	pinMode(MY_RF69_IRQ_PIN, INPUT);
+#endif
+#if !defined(MY_DISABLED_SERIAL)
+	Serial.begin(MY_BAUD_RATE);
+#endif
+	EEPROM.init();
+}
+
+void hwReadConfigBlock(void* buf, void* addr, size_t length)
+{
+	uint8_t* dst = static_cast<uint8_t*>(buf);
+	int pos = reinterpret_cast<int>(addr);
+	while (length-- > 0) {
+		*dst++ = EEPROM.read(pos++);
+	}
+}
+
+void hwWriteConfigBlock(void* buf, void* addr, size_t length)
+{
+	uint8_t* src = static_cast<uint8_t*>(buf);
+	int pos = reinterpret_cast<int>(addr);
+	while (length-- > 0) {
+		EEPROM.write(pos++, *src++);
+	}
+}
+
+uint8_t hwReadConfig(const int addr)
+{
+	uint8_t value;
+	hwReadConfigBlock(&value, reinterpret_cast<void*>(addr), 1);
+	return value;
+}
+
+void hwWriteConfig(const int addr, uint8_t value)
+{
+	hwWriteConfigBlock(&value, reinterpret_cast<void*>(addr), 1);
+}
+
+int8_t hwSleep(unsigned long ms)
+{
+	// TODO: Not supported!
+	(void)ms;
+	return MY_SLEEP_NOT_POSSIBLE;
+}
+
+int8_t hwSleep(uint8_t interrupt, uint8_t mode, unsigned long ms)
+{
+	// TODO: Not supported!
+	(void)interrupt;
+	(void)mode;
+	(void)ms;
+	return MY_SLEEP_NOT_POSSIBLE;
+}
+
+int8_t hwSleep(uint8_t interrupt1, uint8_t mode1, uint8_t interrupt2, uint8_t mode2,
+               unsigned long ms)
+{
+	// TODO: Not supported!
+	(void)interrupt1;
+	(void)mode1;
+	(void)interrupt2;
+	(void)mode2;
+	(void)ms;
+	return MY_SLEEP_NOT_POSSIBLE;
+}
+
+#if defined(MY_DEBUG) || defined(MY_SPECIAL_DEBUG)
+uint16_t hwCPUVoltage()
+{
+    adc_reg_map *regs = ADC1->regs;
+    regs->CR2 |= ADC_CR2_TSVREFE;    // enable VREFINT and temp sensor
+    regs->SMPR1 =  ADC_SMPR1_SMP17;  // sample rate for VREFINT ADC channel
+	return 1200 * 4096 / adc_read(ADC1, 17);
+}
+
+uint16_t hwCPUFrequency()
+{
+	return F_CPU/100000UL;
+}
+
+uint16_t hwFreeMem()
+{
+	//Not yet implemented
+	return 0;
+}
+#endif
+
+#ifdef MY_DEBUG
+void hwDebugPrint(const char *fmt, ... )
+{
+	char fmtBuffer[MY_SERIAL_OUTPUT_SIZE];
+#ifdef MY_GATEWAY_FEATURE
+	// prepend debug message to be handled correctly by controller (C_INTERNAL, I_LOG_MESSAGE)
+	snprintf_P(fmtBuffer, sizeof(fmtBuffer), PSTR("0;255;%d;0;%d;"), C_INTERNAL, I_LOG_MESSAGE);
+	MY_SERIALDEVICE.print(fmtBuffer);
+#else
+	// prepend timestamp (AVR nodes)
+	MY_SERIALDEVICE.print(hwMillis());
+	MY_SERIALDEVICE.print(" ");
+#endif
+	va_list args;
+	va_start (args, fmt );
+#ifdef MY_GATEWAY_FEATURE
+	// Truncate message if this is gateway node
+	vsnprintf_P(fmtBuffer, sizeof(fmtBuffer), fmt, args);
+	fmtBuffer[sizeof(fmtBuffer) - 2] = '\n';
+	fmtBuffer[sizeof(fmtBuffer) - 1] = '\0';
+#else
+	vsnprintf(fmtBuffer, sizeof(fmtBuffer), fmt, args);
+#endif
+	va_end (args);
+	MY_SERIALDEVICE.print(fmtBuffer);
+	MY_SERIALDEVICE.flush();
+
+	//MY_SERIALDEVICE.write(freeRam());
+}
+#endif
+
+#endif // #ifdef ARDUINO_ARCH_STM32F1

--- a/core/MyHwSTM32F1.h
+++ b/core/MyHwSTM32F1.h
@@ -1,0 +1,59 @@
+/**
+ * The MySensors Arduino library handles the wireless radio link and protocol
+ * between your home built sensors/actuators and HA controller of choice.
+ * The sensors forms a self healing radio network with optional repeaters. Each
+ * repeater and gateway builds a routing tables in EEPROM which keeps track of the
+ * network topology allowing messages to be routed to nodes.
+ *
+ * Created by Henrik Ekblad <henrik.ekblad@mysensors.org>
+ * Copyright (C) 2013-2015 Sensnology AB
+ * Full contributor list: https://github.com/mysensors/Arduino/graphs/contributors
+ *
+ * Documentation: http://www.mysensors.org
+ * Support Forum: http://forum.mysensors.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ */
+
+#ifndef MyHwSTM32F1_h
+#define MyHwSTM32F1_h
+
+#include "MyHw.h"
+#include "core/MySensorsCore.h"
+
+#include <libmaple/iwdg.h>
+#include <itoa.h>
+
+#ifdef __cplusplus
+#include <Arduino.h>
+#endif
+
+#ifndef MY_SERIALDEVICE
+#define MY_SERIALDEVICE Serial
+#endif
+
+// Define these as macros to save valuable space
+#define hwDigitalWrite(__pin, __value) digitalWrite(__pin, __value)
+#define hwDigitalRead(__pin) digitalRead(__pin)
+#define hwPinMode(__pin, __value) pinMode(__pin, __value)
+#define hwWatchdogReset() iwdg_feed()
+#define hwReboot() nvic_sys_reset()
+#define hwMillis() millis()
+void (*serialEventRun)() = NULL;
+
+void hwInit(void);
+void hwReadConfigBlock(void* buf, void* adr, size_t length);
+void hwWriteConfigBlock(void* buf, void* adr, size_t length);
+void hwWriteConfig(const int addr, uint8_t value);
+uint8_t hwReadConfig(const int addr);
+
+
+#define hwRandomNumberInit() randomSeed(analogRead(MY_SIGNING_SOFT_RANDOMSEED_PIN))
+
+#ifndef DOXYGEN
+#define MY_CRITICAL_SECTION     ATOMIC_BLOCK(ATOMIC_RESTORESTATE)
+#endif  /* DOXYGEN */
+
+#endif

--- a/core/MyMainSTM32F1.cpp
+++ b/core/MyMainSTM32F1.cpp
@@ -1,0 +1,43 @@
+/**
+ * The MySensors Arduino library handles the wireless radio link and protocol
+ * between your home built sensors/actuators and HA controller of choice.
+ * The sensors forms a self healing radio network with optional repeaters. Each
+ * repeater and gateway builds a routing tables in EEPROM which keeps track of the
+ * network topology allowing messages to be routed to nodes.
+ *
+ * Created by Henrik Ekblad <henrik.ekblad@mysensors.org>
+ * Copyright (C) 2013-2015 Sensnology AB
+ * Full contributor list: https://github.com/mysensors/Arduino/graphs/contributors
+ *
+ * Documentation: http://www.mysensors.org
+ * Support Forum: http://forum.mysensors.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ */
+
+// Initialize library and handle sketch functions like we want to
+
+extern "C" void __libc_init_array(void);
+
+// Force init to be called *first*, i.e. before static object allocation.
+// Otherwise, statically allocated objects that need libmaple may fail.
+ __attribute__(( constructor (101))) void premain() {
+    init();
+}
+
+int main(void) {
+	_begin();
+
+	for(;;) {
+		_process();
+		if (loop) {
+			loop();
+		}
+		if (serialEventRun) {
+			serialEventRun();
+		}
+	}
+    return 0;
+}

--- a/core/MyTransportRFM69.cpp
+++ b/core/MyTransportRFM69.cpp
@@ -22,7 +22,7 @@
 #include <stdint.h>
 #include "drivers/RFM69/RFM69.h"
 
-RFM69 _radio(MY_RF69_SPI_CS, MY_RF69_IRQ_PIN, MY_RFM69HW, MY_RF69_IRQ_NUM);
+RFM69 _radio(MY_RF69_SPI_CS, MY_RF69_IRQ_PIN, MY_RFM69HW, MY_RF69_IRQ_NUM, MY_RF69_SPI_CLOCK_DIV);
 uint8_t _address;
 
 

--- a/drivers/Linux/noniso.cpp
+++ b/drivers/Linux/noniso.cpp
@@ -72,18 +72,18 @@ char* itoa(int value, char* result, int base)
 	return result;
 }
 
-int atoi(const char* s)
+int atoi(const char* s) throw()
 {
 	return (int) atol(s);
 }
 
-long atol(const char* s)
+long atol(const char* s) throw()
 {
 	char * tmp;
 	return strtol(s, &tmp, 10);
 }
 
-double atof(const char* s)
+double atof(const char* s) throw()
 {
 	char * tmp;
 	return strtod(s, &tmp);

--- a/drivers/RFM69/RFM69.cpp
+++ b/drivers/RFM69/RFM69.cpp
@@ -30,7 +30,6 @@
 // **********************************************************************************
 #include "RFM69.h"
 #include "RFM69registers.h"
-#include <SPI.h>
 
 volatile uint8_t RFM69::DATA[RF69_MAX_DATA_LEN];
 volatile uint8_t RFM69::_mode;        // current transceiver state
@@ -500,8 +499,7 @@ void RFM69::select()
 	// set RFM69 SPI settings
 	SPI.setDataMode(SPI_MODE0);
 	SPI.setBitOrder(MSBFIRST);
-	SPI.setClockDivider(
-	    SPI_CLOCK_DIV4); // decided to slow down from DIV2 after SPI stalling in some instances, especially visible on mega1284p when RFM69 and FLASH chip both present
+	SPI.setClockDivider(_spiClockDiv);
 	hwDigitalWrite(_slaveSelectPin, LOW);
 }
 

--- a/drivers/RFM69/RFM69.cpp
+++ b/drivers/RFM69/RFM69.cpp
@@ -497,6 +497,9 @@ void RFM69::select()
 	_SPSR = SPSR;
 #endif
 	// set RFM69 SPI settings
+#ifdef LINUX_ARCH_RASPBERRYPI
+	SPI.beginTransaction(SPISettings());
+#endif
 	SPI.setDataMode(SPI_MODE0);
 	SPI.setBitOrder(MSBFIRST);
 	SPI.setClockDivider(_spiClockDiv);
@@ -513,6 +516,9 @@ void RFM69::unselect()
 	SPSR = _SPSR;
 #endif
 	interrupts();
+#ifdef LINUX_ARCH_RASPBERRYPI
+	SPI.endTransaction();
+#endif
 }
 
 // true  = disable filtering to capture all frames on network

--- a/drivers/RFM69/RFM69.h
+++ b/drivers/RFM69/RFM69.h
@@ -116,7 +116,12 @@ public:
 	{
 		_slaveSelectPin = slaveSelectPin;
 		_interruptPin = interruptPin;
+#ifdef LINUX_ARCH_RASPBERRYPI
+		(void)interruptNum;
+		_interruptNum = digitalPinToInterrupt(interruptPin);
+#else
 		_interruptNum = interruptNum;
+#endif
 		_mode = RF69_MODE_STANDBY;
 		_promiscuousMode = false;
 		_powerLevel = 31;

--- a/drivers/RFM69/RFM69.h
+++ b/drivers/RFM69/RFM69.h
@@ -32,6 +32,8 @@
 #define RFM69_h
 #include <Arduino.h>            // assumes Arduino IDE v1.0 or greater
 
+#include <SPI.h>
+
 #define RF69_MAX_DATA_LEN       61 // to take advantage of the built in AES/CRC we want to limit the frame size to the internal FIFO size (66 bytes - 3 bytes overhead - 2 bytes crc)
 #define RF69_SPI_CS             SS // SS is the SPI slave select pin, for instance D10 on ATmega328
 
@@ -78,6 +80,13 @@
 #define RFM69_CTL_SENDACK   0x80
 #define RFM69_CTL_REQACK    0x40
 
+#if defined(ARDUINO_ARCH_STM32F1)
+#define RF69_SPI_CLOCK_DIV  SPI_CLOCK_DIV32
+#else
+// decided to slow down from DIV2 after SPI stalling in some instances, especially visible on mega1284p when RFM69 and FLASH chip both present
+#define RF69_SPI_CLOCK_DIV  SPI_CLOCK_DIV4
+#endif
+
 /** RFM69 class */
 class RFM69
 {
@@ -100,9 +109,10 @@ public:
 	 * @param interruptPin Interrupt pin.
 	 * @param isRFM69HW Set to @c true to indicate RFM69HW variant.
 	 * @param interruptNum Interrupt number.
+	 * @param spiClockDiv  SPI clock divider
 	 */
 	RFM69(uint8_t slaveSelectPin=RF69_SPI_CS, uint8_t interruptPin=RF69_IRQ_PIN, bool isRFM69HW=false,
-	      uint8_t interruptNum=RF69_IRQ_NUM)
+	      uint8_t interruptNum=RF69_IRQ_NUM, uint8_t spiClockDiv=RF69_SPI_CLOCK_DIV)
 	{
 		_slaveSelectPin = slaveSelectPin;
 		_interruptPin = interruptPin;
@@ -111,6 +121,7 @@ public:
 		_promiscuousMode = false;
 		_powerLevel = 31;
 		_isRFM69HW = isRFM69HW;
+		_spiClockDiv = spiClockDiv;
 		_address = RF69_BROADCAST_ADDR;
 #if defined (SPCR) && defined (SPSR)
 		_SPCR = 0;
@@ -161,6 +172,7 @@ protected:
 	uint8_t _interruptPin; //!< _interruptPin
 	uint8_t _interruptNum; //!< _interruptNum
 	uint8_t _address; //!< _address
+	uint8_t _spiClockDiv; //!< _spiClockDiv
 	bool _promiscuousMode; //!< _promiscuousMode
 	uint8_t _powerLevel; //!< _powerLevel
 	bool _isRFM69HW; //!< _isRFM69HW


### PR DESCRIPTION
This patch enables the use of the RFM69W modules directly connected to the Raspberry Pi headers (no arduino gateway needed)

Note that we use software chip-select because we need to query the 1st byte to determine how many bytes to read without de-asserting chip-select, and the hardware chip-select does not support this.  I have code to do this reusing the CS0 pin, but it required less change to use a separate pin, so I've started with that.

the configure command I used is:
./configure --my-gateway=mqtt --my-controller-ip-address=127.0.0.1 --my-mqtt-publish-topic-prefix=mysensors-out --my-mqtt-subscribe-topic-prefix=mysensors-in --my-mqtt-client-id=mygateway1 --my-transport=rfm69 --my-is-rfm69hw --my-rfm69-frequency=433 --my-rf69-irq-pin=10 --my-rf69-spi-cs=22 --my-rf69-spi-clock-div=250

This puts the IRQ pin on header-pin 10 and the chip-select on header pin 22 and uses a 1MHz clock (May be 1.6MHz on RPi3 depending on bus frequency)
