### PR TITLE
Add MQTT Auth for RPi

### DIFF
--- a/configure
+++ b/configure
@@ -53,6 +53,8 @@ MySensors options:
     --my-serial-pty=<NAME>      Symlink name for the PTY device. [/dev/ttyMySensorsGateway]
     --my-serial-groupname=<GROUP>
                                 Grant access to the specified system group for the serial device.
+    --my-mqtt-user=<UID>        MQTT user id.
+    --my-mqtt-password=<PASS>   MQTT password                              
     --my-mqtt-client-id=<ID>    MQTT client id.
     --my-mqtt-publish-topic-prefix=<PREFIX>
                                 MQTT publish topic prefix.
@@ -351,6 +353,12 @@ for opt do
     --my-port=*)
         CPPFLAGS="-DMY_PORT=${optarg} $CPPFLAGS"
         ;;
+    --my-mqtt-user=*)
+        CPPFLAGS="-DMY_MQTT_USER=\\\"${optarg}\\\" $CPPFLAGS"
+        ;;
+    --my-mqtt-password=*)
+        CPPFLAGS="-DMY_MQTT_PASSWORD=\\\"${optarg}\\\" $CPPFLAGS"
+        ;;     
     --my-mqtt-client-id=*)
         CPPFLAGS="-DMY_MQTT_CLIENT_ID=\\\"${optarg}\\\" $CPPFLAGS"
         ;;


### PR DESCRIPTION
First time contributing, and still learning git,

These username and password options need to be added to allow users to configure a raspberry pi MQTT gateway.

Here is the "configure" file that has been corrected