### PR TITLE
Workaround for AVR-specific compiler issue

### DIFF
--- a/MyConfig.h
+++ b/MyConfig.h
@@ -303,6 +303,12 @@
 
 //#define MY_WITH_LEDS_BLINKING_INVERSE
 
+/**
+* @def MY_INDICATION_HANDLER
+* @brief Enable to use own indication handler
+*/
+//#define MY_INDICATION_HANDLER
+
 
 /**********************************************
 *  Gateway inclusion button/mode configuration
@@ -959,4 +965,5 @@
 #define MY_LINUX_IS_SERIAL_PTY
 #define MY_RFM95_ATC_MODE_DISABLED
 #define MY_RFM95_RST_PIN
+#define MY_INDICATION_HANDLER
 #endif

--- a/core/MyIndication.cpp
+++ b/core/MyIndication.cpp
@@ -40,7 +40,13 @@ void setIndication( const indication_t ind )
 				ledsBlinkErr(ind-INDICATION_ERR_START);
 			}
 #endif
-	if (indication) {
-		indication(ind);
-	}
+	indication(ind);
 }
+
+#if !defined(MY_INDICATION_HANDLER)
+void indication(indication_t)
+{
+	// empty function, resolves AVR-specific GCC optimization bug (<5.5) if handler not used
+	// see here: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=77326
+}
+#endif

--- a/core/MyIndication.h
+++ b/core/MyIndication.h
@@ -74,6 +74,6 @@ void setIndication( const indication_t ind );
 /**
  * Allow user to define their own indication handler.
  */
-void indication( const indication_t ) __attribute__((weak));
+void indication( const indication_t );
 
 #endif


### PR DESCRIPTION
- weak function definitions can cause a context-dependent null pointer execution. This has been observed for indication().
- To use own indication handler, define MY_INDICATION_HANDLER
