### PR TITLE
rf24: support two-pin exchange

### DIFF
--- a/MyConfig.h
+++ b/MyConfig.h
@@ -507,7 +507,7 @@
 
 /**
  * @def MY_RF24_CS_PIN
- * @brief Default RF24 chip select pin setting. Override in sketch if needed.
+ * @brief Default RF24 chip select pin setting. Override in sketch if needed. To save the MCU pin set this to -1 and connect CE to VCC.
  */
 #ifndef MY_RF24_CS_PIN
 #if defined(ARDUINO_ARCH_ESP8266)

--- a/MySensors.h
+++ b/MySensors.h
@@ -245,9 +245,10 @@ MY_DEFAULT_RX_LED_PIN in your sketch instead to enable LEDs
 // SOFTSPI
 #ifdef MY_SOFTSPI
 #if defined(ARDUINO_ARCH_ESP8266)
-#error Soft SPI is not available on ESP8266
-#endif
+#include "drivers/ESP8266/SoftSPI.h"
+#else
 #include "drivers/AVR/DigitalIO/DigitalIO.h"
+#endif
 #endif
 
 #if defined(MY_RADIO_NRF24) && defined(__linux__) && !(defined(LINUX_SPI_BCM) || defined(LINUX_SPI_SPIDEV))

--- a/core/MyGatewayTransportEthernet.cpp
+++ b/core/MyGatewayTransportEthernet.cpp
@@ -299,10 +299,10 @@ bool gatewayTransportAvailable(void)
 	if (packet_size) {
 		//debug(PSTR("UDP packet available. Size:%d\n"), packet_size);
 #if defined(MY_GATEWAY_ESP8266)
-		_ethernetServer.read(inputString[0].string, MY_GATEWAY_MAX_RECEIVE_LENGTH);
-		inputString[0].string[packet_size] = 0;
-		debug(PSTR("UDP packet received: %s\n"), inputString[0].string);
-		const bool ok = protocolParse(_ethernetMsg, inputString[0].string);
+		_ethernetServer.read(inputString.string, MY_GATEWAY_MAX_RECEIVE_LENGTH);
+		inputString.string[packet_size] = 0;
+		debug(PSTR("UDP packet received: %s\n"), inputString.string);
+		const bool ok = protocolParse(_ethernetMsg, inputString.string);
 #else
 		_ethernetServer.read(inputString.string, MY_GATEWAY_MAX_RECEIVE_LENGTH);
 		inputString.string[packet_size] = 0;

--- a/drivers/ESP8266/SoftSPI.h
+++ b/drivers/ESP8266/SoftSPI.h
@@ -1,0 +1,71 @@
+/* Arduino SoftSPI Library adapted for ESP8266
+ * Copyright (C) 2013 by William Greiman
+ * Copyright (C) 2017 by Vladimir Dronnikov
+ *
+ * This file is part of the Arduino DigitalIO Library
+ *
+ * This Library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This Library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with the Arduino DigitalIO Library.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+/**
+ * @file
+ * @brief  Software SPI.
+ *
+ * @defgroup softSPI Software SPI
+ * @ingroup internals
+ * @details  Software SPI Template Class.
+ * @{
+ */
+
+#ifndef SoftSPI_h
+#define SoftSPI_h
+
+//------------------------------------------------------------------------------
+/**
+ * @class SoftSPI
+ * @brief Fast software SPI.
+ */
+template<uint8_t MisoPin, uint8_t MosiPin, uint8_t SckPin, uint8_t Mode = 0>
+class SoftSPI
+{
+public:
+	//----------------------------------------------------------------------------
+	/** Initialize SoftSPI pins. */
+	void begin()
+	{
+		pinMode(MisoPin, INPUT);
+		pinMode(MosiPin, OUTPUT);
+		pinMode(SckPin, OUTPUT);
+	}
+	//----------------------------------------------------------------------------
+	/** Soft SPI transfer byte.
+	 * @param[in] txData Data byte to send.
+	 * @return Data byte received.
+	 */
+	uint8_t transfer(uint8_t txData)
+	{
+		uint8_t rxData, bits = 8;
+		do {
+			digitalWrite(MosiPin, txData & 0x80);
+			digitalWrite(SckPin, HIGH);
+			rxData <<= 1;
+			if (digitalRead(MisoPin)) ++rxData;
+			txData <<= 1;
+			digitalWrite(SckPin, LOW);
+		} while (--bits);
+		return rxData;
+	}
+};
+#endif  // SoftSPI_h
+/** @} */

--- a/drivers/RF24/RF24.cpp
+++ b/drivers/RF24/RF24.cpp
@@ -34,6 +34,10 @@ uint8_t spi_rxbuff[32+1] ; //SPI receive buffer (payload max 32 bytes)
 uint8_t spi_txbuff[32+1] ; //SPI transmit buffer (payload max 32 bytes + 1 byte for the command)
 #endif
 
+#if defined(ARDUINO_ARCH_ESP8266)
+#define fastDigitalWrite digitalWrite
+#endif
+
 #if defined(MY_RF24_MOMI_PIN)
 
 LOCAL void RF24_csn(const bool level)

--- a/drivers/RF24/RF24.cpp
+++ b/drivers/RF24/RF24.cpp
@@ -82,7 +82,9 @@ LOCAL void RF24_csn(const bool level)
 
 LOCAL void RF24_ce(const bool level)
 {
+#if MY_RF24_CE_PIN != -1
 	fastDigitalWrite(MY_RF24_CE_PIN, level);
+#endif
 }
 
 #endif
@@ -455,7 +457,9 @@ LOCAL bool RF24_initialize(void)
 #if defined(MY_RF24_MOMI_PIN)
 	hwPinMode(MY_RF24_SCLK_PIN,OUTPUT);
 #else
+#if MY_RF24_CE_PIN != -1
 	hwPinMode(MY_RF24_CE_PIN,OUTPUT);
+#endif
 	hwPinMode(MY_RF24_CS_PIN,OUTPUT);
 #endif
 #if defined(MY_RX_MESSAGE_BUFFER_FEATURE)

--- a/drivers/RF24/RF24.cpp
+++ b/drivers/RF24/RF24.cpp
@@ -39,10 +39,11 @@ uint8_t spi_txbuff[32+1] ; //SPI transmit buffer (payload max 32 bytes + 1 byte 
 #endif
 
 #if defined(MY_RF24_MOMI_PIN)
+#include "drivers/AVR/DigitalIO/DigitalIO.h"
 
 LOCAL void RF24_csn(const bool level)
 {
-	hwDigitalWrite(MY_RF24_SCLK_PIN, level);
+	fastDigitalWrite(MY_RF24_SCLK_PIN, level);
 }
 
 LOCAL void RF24_ce(const bool level)
@@ -54,17 +55,19 @@ LOCAL uint8_t RF24_transfer(uint8_t txData)
 	uint8_t rxData, bits = 8;
 	do {
 		rxData <<= 1;
-		if (hwDigitalRead(MY_RF24_MOMI_PIN)) {
+		if (fastDigitalRead(MY_RF24_MOMI_PIN)) {
 			++rxData;
 		}
-		hwPinMode(MY_RF24_MOMI_PIN, OUTPUT);
+		// hwPinMode(MY_RF24_MOMI_PIN, OUTPUT);
+		fastPinConfig(MY_RF24_MOMI_PIN, OUTPUT, 0);
 		if (txData & 0x80) {
-			hwDigitalWrite(MY_RF24_MOMI_PIN, HIGH);
+			fastDigitalWrite(MY_RF24_MOMI_PIN, HIGH);
 		}
-		hwDigitalWrite(MY_RF24_SCLK_PIN, HIGH);
-		hwPinMode(MY_RF24_MOMI_PIN, INPUT);
-		hwDigitalWrite(MY_RF24_SCLK_PIN, LOW);
-		hwDigitalWrite(MY_RF24_MOMI_PIN, LOW);
+		fastDigitalWrite(MY_RF24_SCLK_PIN, HIGH);
+		// hwPinMode(MY_RF24_MOMI_PIN, INPUT);
+		fastPinConfig(MY_RF24_MOMI_PIN, INPUT, 0);
+		fastDigitalWrite(MY_RF24_SCLK_PIN, LOW);
+		fastDigitalWrite(MY_RF24_MOMI_PIN, LOW);
 		txData <<= 1;
 	} while (--bits);
 	return rxData;
@@ -74,12 +77,12 @@ LOCAL uint8_t RF24_transfer(uint8_t txData)
 
 LOCAL void RF24_csn(const bool level)
 {
-	hwDigitalWrite(MY_RF24_CS_PIN, level);
+	fastDigitalWrite(MY_RF24_CS_PIN, level);
 }
 
 LOCAL void RF24_ce(const bool level)
 {
-	hwDigitalWrite(MY_RF24_CE_PIN, level);
+	fastDigitalWrite(MY_RF24_CE_PIN, level);
 }
 
 #endif
@@ -100,7 +103,7 @@ LOCAL uint8_t RF24_spiMultiByteTransfer(const uint8_t cmd, uint8_t* buf, uint8_t
 #if defined(MY_RF24_MOMI_PIN)
 	delayMicroseconds(100);
 #else
-	delayMicroseconds(10);
+	delayMicroseconds(1);
 #endif
 #if defined(MY_RF24_MOMI_PIN)
 	status = RF24_transfer(cmd);
@@ -162,9 +165,9 @@ LOCAL uint8_t RF24_spiMultiByteTransfer(const uint8_t cmd, uint8_t* buf, uint8_t
 #endif
 	// timing
 #if defined(MY_RF24_MOMI_PIN)
-	delayMicroseconds(100);
+	delayMicroseconds(1); // 100
 #else
-	delayMicroseconds(10);
+	delayMicroseconds(1);
 #endif
 	return status;
 }

--- a/drivers/RF24/RF24.h
+++ b/drivers/RF24/RF24.h
@@ -68,6 +68,10 @@ extern HardwareSPI SPI;
 #ifdef MY_SOFTSPI
 #error RF24 IRQ usage cannot be used with Soft SPI
 #endif
+// Two-pin RF24 does not support usingInterrupt()
+#ifdef MY_RF24_MOMI_PIN
+#error RF24 IRQ usage cannot be used with Soft SPI
+#endif
 // ESP8266 does not support usingInterrupt()
 #ifdef ARDUINO_ARCH_ESP8266
 #error RF24 IRQ usage cannot be used with ESP8266

--- a/examples/GatewaySerialTwoPins/GatewaySerialTwoPins.ino
+++ b/examples/GatewaySerialTwoPins/GatewaySerialTwoPins.ino
@@ -1,0 +1,59 @@
+/**
+* The MySensors Arduino library handles the wireless radio link and protocol
+* between your home built sensors/actuators and HA controller of choice.
+* The sensors forms a self healing radio network with optional repeaters. Each
+* repeater and gateway builds a routing tables in EEPROM which keeps track of the
+* network topology allowing messages to be routed to nodes.
+*
+* Created by Henrik Ekblad <henrik.ekblad@mysensors.org>
+* Copyright (C) 2013-2015 Sensnology AB
+* Full contributor list: https://github.com/mysensors/Arduino/graphs/contributors
+*
+* Documentation: http://www.mysensors.org
+* Support Forum: http://forum.mysensors.org
+*
+* This program is free software; you can redistribute it and/or
+* modify it under the terms of the GNU General Public License
+* version 2 as published by the Free Software Foundation.
+*
+*******************************
+*
+* DESCRIPTION
+* The ArduinoGateway prints data received from sensors on the serial link.
+* The gateway accepts input on seral which will be sent out on radio network.
+*
+* The GW code is designed for Arduino Nano 328p / 16MHz
+*
+*/
+
+// Enable and select radio type attached
+#define MY_RADIO_NRF24
+
+// Set LOW transmit power level as default, if you have an amplified NRF-module and
+// power your radio separately with a good regulator you can turn up PA level.
+#define MY_RF24_PA_LEVEL RF24_PA_LOW
+
+// Setup two-pins NRF24L01+ mode
+// See http://nerdralph.blogspot.ru/2015/05/nrf24l01-control-with-2-mcu-pins-using.html for hardware description.
+#define MY_RF24_MOMI_PIN A2
+#define MY_RF24_SCLK_PIN A3
+
+// Enable serial gateway
+#define MY_GATEWAY_SERIAL
+
+#include <MySensors.h>
+
+void setup()
+{
+	// Setup locally attached sensors
+}
+
+void presentation()
+{
+	// Present locally attached sensors
+}
+
+void loop()
+{
+	// Send locally attached sensor data here
+}


### PR DESCRIPTION
Hello!

This patch allows to operate on NRF24L01+ via 2 pins -- see See http://nerdralph.blogspot.ru/2015/05/nrf24l01-control-with-2-mcu-pins-using.html for hardware description.

Wonder if it's worth living in the core and if it's ever welcome for mysensors community.

TIA,
--Vladimir
