### PR TITLE
Add function to retrieve unique ID

### DIFF
--- a/core/MyHw.h
+++ b/core/MyHw.h
@@ -56,6 +56,9 @@ uint8_t hwReadConfig(int adr);
  * @param ms   Time to sleep, in [ms].
  * @return Nonsense, please ignore.
  */
+
+typedef uint8_t unique_id_t[16];
+
 int8_t hwSleep(unsigned long ms);
 
 /**
@@ -78,6 +81,13 @@ int8_t hwSleep(uint8_t interrupt, uint8_t mode, unsigned long ms);
  */
 int8_t hwSleep(uint8_t interrupt1, uint8_t mode1, uint8_t interrupt2, uint8_t mode2,
                unsigned long ms);
+
+/**
+* Retrieve unique ID
+* @param uniqueID uniqueID
+* @return True if unique ID successfully retrieved
+*/
+bool hwUniqueID(unique_id_t* uniqueID);
 
 #if defined(MY_DEBUG) || defined(MY_SPECIAL_DEBUG)
 /**

--- a/core/MyHwAVR.cpp
+++ b/core/MyHwAVR.cpp
@@ -197,6 +197,13 @@ int8_t hwSleep(uint8_t interrupt1, uint8_t mode1, uint8_t interrupt2, uint8_t mo
 	return ret;
 }
 
+
+bool hwUniqueID(unique_id_t* uniqueID)
+{
+	// not implemented yet
+	(void)uniqueID;
+	return false;
+}
 #if defined(MY_DEBUG) || defined(MY_SPECIAL_DEBUG)
 uint16_t hwCPUVoltage()
 {

--- a/core/MyHwESP8266.cpp
+++ b/core/MyHwESP8266.cpp
@@ -61,6 +61,17 @@ void hwWriteConfig(const int addr, uint8_t value)
 	hwWriteConfigBlock(&value, reinterpret_cast<void*>(addr), 1);
 }
 
+bool hwUniqueID(unique_id_t *uniqueID)
+{
+	// padding
+	memset((uint8_t*)uniqueID, 0x0A, sizeof(unique_id_t));
+	uint32_t val = ESP.getChipId();
+	(void)memcpy((uint8_t*)uniqueID, &val, 4);
+	val = ESP.getFlashChipId();
+	(void)memcpy((uint8_t*)uniqueID + 4, &val, 4);
+	return true;
+}
+
 
 int8_t hwSleep(unsigned long ms)
 {

--- a/core/MyHwLinuxGeneric.cpp
+++ b/core/MyHwLinuxGeneric.cpp
@@ -69,6 +69,13 @@ unsigned long hwMillis()
 	return millis();
 }
 
+bool hwUniqueID(unique_id_t *uniqueID)
+{
+	// not implemented yet
+	(void)uniqueID;
+	return false;
+}
+
 // Not supported!
 int8_t hwSleep(unsigned long ms)
 {

--- a/core/MyHwSAMD.cpp
+++ b/core/MyHwSAMD.cpp
@@ -147,6 +147,13 @@ int8_t hwSleep(uint8_t interrupt1, uint8_t mode1, uint8_t interrupt2, uint8_t mo
 	return MY_SLEEP_NOT_POSSIBLE;
 }
 
+bool hwUniqueID(unique_id_t *uniqueID)
+{
+	(void)memcpy((uint8_t*)uniqueID, (uint32_t *)0x0080A00C, 4);
+	(void)memcpy((uint8_t*)uniqueID + 4, (uint32_t *)0x0080A040, 12);
+	return true;
+}
+
 #if defined(MY_DEBUG) || defined(MY_SPECIAL_DEBUG)
 uint16_t hwCPUVoltage()
 {


### PR DESCRIPTION
- hwUniqueID() retrieves unique chip ID (if present)
- currently supported: SAMD, ESP8266