### PR TITLE
Clear RX flag in RF24_irqHandler

### DIFF
--- a/drivers/RF24/RF24.cpp
+++ b/drivers/RF24/RF24.cpp
@@ -357,8 +357,13 @@ LOCAL void RF24_irqHandler(void)
 
 		// Start checking if RX-FIFO is not empty, as we might end up here from an interrupt
 		// for a message we've already read.
-		while (RF24_isDataAvailable()) {
-			RF24_receiveCallback();		// Must call RF24_readMessage(), which will clear RX_DR IRQ !
+		if (RF24_isDataAvailable()) {
+			do {
+				RF24_receiveCallback();		// Must call RF24_readMessage(), which will clear RX_DR IRQ !
+			} while (RF24_isDataAvailable());
+		} else {
+			// Occasionally interrupt is triggered but no data available - clear RX interrupt only
+			RF24_setStatus(_BV(RF24_RX_DR));
 		}
 		// Restore our interrupt handler.
 #if defined(MY_GATEWAY_SERIAL) && !defined(__linux__)


### PR DESCRIPTION
Fix for using IRQ pin with NRF24. This should fix issue when gateway or node stops receiving packets after some time.
Tested on Raspberry Pi gateway with --my-rf24-irq-pin option and with repeater node on Nano.