### PR TITLE
Fix watchdog sleep calculation

### DIFF
--- a/core/MyHwAVR.h
+++ b/core/MyHwAVR.h
@@ -54,20 +54,6 @@ bool hwInit(void);
 #define hwReadConfigBlock(__buf, __pos, __length) eeprom_read_block((void*)(__buf), (void*)(__pos), (__length))
 #define hwWriteConfigBlock(__buf, __pos, __length) eeprom_update_block((void*)(__buf), (void*)(__pos), (__length))
 
-enum period_t {
-	SLEEP_15MS,
-	SLEEP_30MS,
-	SLEEP_60MS,
-	SLEEP_120MS,
-	SLEEP_250MS,
-	SLEEP_500MS,
-	SLEEP_1S,
-	SLEEP_2S,
-	SLEEP_4S,
-	SLEEP_8S,
-	SLEEP_FOREVER
-};
-
 void hwInternalSleep(unsigned long ms);
 
 #ifndef DOXYGEN


### PR DESCRIPTION
Round requested sleep time up to next multiple of 16ms, to sleep at
least requested time.
Sleep time of 0 will return immediately.
Fixed watchdog sleep time calculation. AVR libc watchdog time
implementation is inconsistent, and requires larger flash/ram usage.