### PR TITLE
Sleep tweak: clear interrupt flag based on the interrupt used.

### DIFF
--- a/core/MyHwAVR.cpp
+++ b/core/MyHwAVR.cpp
@@ -163,11 +163,11 @@ int8_t hwSleep(uint8_t interrupt1, uint8_t mode1, uint8_t interrupt2, uint8_t mo
 	// to prevent waking immediately again.
 	// Ref: https://forum.arduino.cc/index.php?topic=59217.0
 	if (interrupt1 != INVALID_INTERRUPT_NUM) {
-		EIFR = _BV(INTF0);
+		EIFR = _BV(interrupt1 == 0 ? INTF0 : INTF1);
 		attachInterrupt(interrupt1, wakeUp1, mode1);
 	}
 	if (interrupt2 != INVALID_INTERRUPT_NUM) {
-		EIFR = _BV(INTF1);
+		EIFR = _BV(interrupt2 == 0 ? INTF0 : INTF1);
 		attachInterrupt(interrupt2, wakeUp2, mode2);
 	}
 


### PR DESCRIPTION
This is a small tweak to the last sleep fix. The last fix would clear the proper interrupt flag assuming interrupt1 is INT0 and interrupt2 is INT1. If interrupt1 is INT1 or interrupt2 is INT0, the sleep bug is still triggered.

e.g. `sleep(digitalPinToInterrupt(2), CHANGE, 0);` sleep bug is fixed
 `sleep(digitalPinToInterrupt(3), CHANGE, 0)` still triggers the sleep bug

CC: @Yveaux