### PR TITLE
Fix clear pending ints for AVR

### DIFF
--- a/core/MyHwAVR.cpp
+++ b/core/MyHwAVR.cpp
@@ -27,7 +27,7 @@ bool hwInit(void)
 	return true;
 }
 
-#define WDTO_SLEEP_FOREVER      (0xFFu)
+#define WDTO_SLEEP_FOREVER		(0xFFu)
 #define INVALID_INTERRUPT_NUM	(0xFFu)
 
 volatile uint8_t _wokeUpByInterrupt =
@@ -64,6 +64,11 @@ void wakeUp2()
 inline bool interruptWakeUp()
 {
 	return _wokeUpByInterrupt != INVALID_INTERRUPT_NUM;
+}
+
+void clearPendingInterrupt(const uint8_t interrupt)
+{
+	EIFR = _BV(interrupt);
 }
 
 // Watchdog Timer interrupt service routine. This routine is required
@@ -163,11 +168,11 @@ int8_t hwSleep(uint8_t interrupt1, uint8_t mode1, uint8_t interrupt2, uint8_t mo
 	// to prevent waking immediately again.
 	// Ref: https://forum.arduino.cc/index.php?topic=59217.0
 	if (interrupt1 != INVALID_INTERRUPT_NUM) {
-		EIFR = _BV(interrupt1 == 0 ? INTF0 : INTF1);
+		clearPendingInterrupt(interrupt1);
 		attachInterrupt(interrupt1, wakeUp1, mode1);
 	}
 	if (interrupt2 != INVALID_INTERRUPT_NUM) {
-		EIFR = _BV(interrupt2 == 0 ? INTF0 : INTF1);
+		clearPendingInterrupt(interrupt2);
 		attachInterrupt(interrupt2, wakeUp2, mode2);
 	}
 


### PR DESCRIPTION
Support full AVR range, not only the ones supporting external interrupts 0 & 1.
Only tested on ATMega328 hardware however, as I have no other AVRs available ;-(