### PR TITLE
Corrections for stm32f1 serial communication

### DIFF
--- a/core/MyHwSTM32F1.cpp
+++ b/core/MyHwSTM32F1.cpp
@@ -47,7 +47,7 @@
 bool hwInit(void)
 {
 #if !defined(MY_DISABLED_SERIAL)
-	Serial.begin(MY_BAUD_RATE);
+	MY_SERIALDEVICE.begin(MY_BAUD_RATE);
 #endif
 	if (EEPROM.init() == EEPROM_OK) {
 
@@ -170,5 +170,7 @@ void hwDebugPrint(const char *fmt, ...)
 #endif
 	va_end(args);
 	MY_SERIALDEVICE.print(fmtBuffer);
-	MY_SERIALDEVICE.flush();
+	// Disable flush since current STM32duino implementation performs a reset
+	// instead of an actual flush
+	//MY_SERIALDEVICE.flush();
 }


### PR DESCRIPTION
I experienced some issues trying to use Serial1 on a STM32F103C8. This PR should address these:

- use MY_SERIALDEVICE in hwInit
- disable use of MY_SERIALDEVICE.flush() since the current STM32duino implementation performs a reset instead of an actual flush: 