### PR TITLE
Update MyIndication.cpp

### DIFF
--- a/core/MyIndication.cpp
+++ b/core/MyIndication.cpp
@@ -18,9 +18,7 @@
  */
 
 #include "MyIndication.h"
-#if defined(MY_DEFAULT_TX_LED_PIN)|| defined(MY_DEFAULT_RX_LED_PIN) || defined(MY_DEFAULT_ERR_LED_PIN)
-#include "MyLeds.h"
-#endif
+
 
 void setIndication( const indication_t ind )
 {

--- a/core/MyIndication.cpp
+++ b/core/MyIndication.cpp
@@ -19,7 +19,6 @@
 
 #include "MyIndication.h"
 
-
 void setIndication( const indication_t ind )
 {
 #if defined(MY_DEFAULT_TX_LED_PIN)


### PR DESCRIPTION
In MyIndication.cpp there is a 'ifdef' sentence with the inclusion of MyLeds.h 
This was removed since it is not required because it's already handled by MySensors.h:

#if defined(MY_DEFAULT_RX_LED_PIN) || defined(MY_DEFAULT_TX_LED_PIN)
#|| defined(MY_DEFAULT_ERR_LED_PIN)
#include "core/MyLeds.cpp"
#else
#include "core/MyLeds.h"
#endif