### PR TITLE
Enhance randomness (AVR, ESP8266, Linux, NRF5)

### DIFF
--- a/core/MySigningAtsha204Soft.cpp
+++ b/core/MySigningAtsha204Soft.cpp
@@ -109,6 +109,10 @@ bool signerAtsha204SoftGetNonce(MyMessage &msg)
 	}
 	SIGN_DEBUG(PSTR("Signing backend: ATSHA204Soft\n"));
 
+#ifdef MY_HW_HAS_GETRANDOM
+	// Try to get MAX_PAYLOAD random bytes
+	while (hwGetentropy(&_signing_verifying_nonce, MAX_PAYLOAD) != MAX_PAYLOAD);
+#else
 	// We used a basic whitening technique that XORs a random byte with the current hwMillis() counter and then the byte is
 	// hashed (SHA256) to produce the resulting nonce
 	_signing_sha256.init();
@@ -116,6 +120,7 @@ bool signerAtsha204SoftGetNonce(MyMessage &msg)
 		_signing_sha256.write(random(256) ^ (hwMillis()&0xFF));
 	}
 	memcpy(_signing_verifying_nonce, _signing_sha256.result(), MAX_PAYLOAD);
+#endif
 
 	// We set the part of the 32-byte nonce that does not fit into a message to 0xAA
 	memset(&_signing_verifying_nonce[MAX_PAYLOAD], 0xAA, sizeof(_signing_verifying_nonce)-MAX_PAYLOAD);

--- a/examples/SecurityPersonalizer/SecurityPersonalizer.ino
+++ b/examples/SecurityPersonalizer/SecurityPersonalizer.ino
@@ -72,7 +72,7 @@
  *
  * @b Important<br>
  * You will need to ensure @ref MY_SIGNING_SOFT_RANDOMSEED_PIN is set to an unconnected analog pin
- * in order to provide entropy to the software RNG.
+ * in order to provide entropy to the software RNG if your hardware has no HWRNG.
  *
  * @note The generated keys displayed in the serial log with this setting needs to be written down
  *       and transferred to all nodes this gateway will communicate with. This is mandatory for ALL
@@ -436,7 +436,7 @@ void setup()
 	while (hwMillis() - enter < (unsigned long)500);
 #ifdef USE_SOFT_SIGNING
 	// initialize pseudo-RNG
-	randomSeed(analogRead(MY_SIGNING_SOFT_RANDOMSEED_PIN));
+	hwRandomNumberInit();
 #endif
 
 	Serial.begin(MY_BAUD_RATE);

--- a/hal/architecture/MyHw.h
+++ b/hal/architecture/MyHw.h
@@ -44,6 +44,14 @@ uint8_t hwReadConfig(int adr);
 */
 
 /**
+ * @def MY_HW_HAS_GETRANDOM
+ * @brief Define this, if hwGetentropy is implemented
+ *
+ * ssize_t hwGetentropy(void *__buffer, size_t __length);
+ */
+//#define MY_HW_HAS_GETRANDOM
+
+/**
  * Sleep for a defined time, using minimum power.
  * @param ms   Time to sleep, in [ms].
  * @return Nonsense, please ignore.
@@ -138,6 +146,7 @@ void hwDebugPrint(const char *fmt, ... );
  */
 #ifdef DOXYGEN
 #define MY_CRITICAL_SECTION
+#define MY_HW_HAS_GETRANDOM
 #endif  /* DOXYGEN */
 
 #endif // #ifdef MyHw_h

--- a/hal/architecture/MyHwAVR.h
+++ b/hal/architecture/MyHwAVR.h
@@ -48,12 +48,12 @@ bool hwInit(void);
 #define hwWatchdogReset() wdt_reset()
 #define hwReboot() wdt_enable(WDTO_15MS); while (1)
 #define hwMillis() millis()
-#define hwRandomNumberInit() randomSeed(analogRead(MY_SIGNING_SOFT_RANDOMSEED_PIN))
 #define hwReadConfig(__pos) eeprom_read_byte((uint8_t*)(__pos))
 #define hwWriteConfig(__pos, __val) eeprom_update_byte((uint8_t*)(__pos), (__val))
 #define hwReadConfigBlock(__buf, __pos, __length) eeprom_read_block((void*)(__buf), (void*)(__pos), (__length))
 #define hwWriteConfigBlock(__buf, __pos, __length) eeprom_update_block((void*)(__buf), (void*)(__pos), (__length))
 
+inline void hwRandomNumberInit();
 void hwInternalSleep(unsigned long ms);
 
 #ifndef DOXYGEN

--- a/hal/architecture/MyHwESP8266.cpp
+++ b/hal/architecture/MyHwESP8266.cpp
@@ -73,6 +73,21 @@ bool hwUniqueID(unique_id_t *uniqueID)
 	return true;
 }
 
+ssize_t hwGetentropy(void *__buffer, size_t __length)
+{
+	// cut length if > 256
+	if (__length > 256) {
+		__length = 256;
+	}
+	uint8_t *dst = (uint8_t *)__buffer;
+
+	// Start random number generator
+	for (size_t i = 0; i < __length; i++) {
+		dst[i] = (uint8_t)RANDOM_REG32;
+	}
+
+	return __length;
+}
 
 int8_t hwSleep(unsigned long ms)
 {

--- a/hal/architecture/MyHwESP8266.h
+++ b/hal/architecture/MyHwESP8266.h
@@ -41,13 +41,16 @@
 #define hwWatchdogReset() wdt_reset()
 #define hwReboot() ESP.restart()
 #define hwMillis() millis()
-#define hwRandomNumberInit() randomSeed(RANDOM_REG32)
+// The use of randomSeed switch to pseudo random number. Keep hwRandomNumberInit empty
+#define hwRandomNumberInit()
 
 bool hwInit(void);
 void hwReadConfigBlock(void* buf, void* adr, size_t length);
 void hwWriteConfigBlock(void* buf, void* adr, size_t length);
 void hwWriteConfig(const int addr, uint8_t value);
 uint8_t hwReadConfig(const int addr);
+ssize_t hwGetentropy(void *__buffer, size_t __length);
+//#define MY_HW_HAS_GETRANDOM
 
 /**
  * Restore interrupt state.

--- a/hal/architecture/MyHwLinuxGeneric.cpp
+++ b/hal/architecture/MyHwLinuxGeneric.cpp
@@ -19,7 +19,13 @@
 
 #include "MyHwLinuxGeneric.h"
 
+#include <errno.h>
+#include <linux/random.h>
 #include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <syscall.h>
+#include <unistd.h>
 #include <time.h>
 #include "SoftEeprom.h"
 #include "log.h"
@@ -62,7 +68,15 @@ void hwWriteConfig(int addr, uint8_t value)
 
 void hwRandomNumberInit()
 {
-	randomSeed(time(NULL));
+	unsigned long seed=0;
+	while (hwGetentropy(&seed, sizeof(seed)) != sizeof(seed));
+	randomSeed(seed);
+}
+
+ssize_t hwGetentropy(void *__buffer, size_t __length)
+{
+	// getrandom syscall
+	return syscall(SYS_getrandom, __buffer, __length, GRND_NONBLOCK);
 }
 
 unsigned long hwMillis()

--- a/hal/architecture/MyHwLinuxGeneric.h
+++ b/hal/architecture/MyHwLinuxGeneric.h
@@ -54,6 +54,8 @@ inline void hwWriteConfigBlock(void* buf, void* addr, size_t length);
 inline uint8_t hwReadConfig(int addr);
 inline void hwWriteConfig(int addr, uint8_t value);
 inline void hwRandomNumberInit();
+ssize_t hwGetentropy(void *__buffer, size_t __length);
+#define MY_HW_HAS_GETRANDOM
 inline unsigned long hwMillis();
 
 #ifdef MY_RF24_IRQ_PIN

--- a/hal/architecture/MyHwNRF5.h
+++ b/hal/architecture/MyHwNRF5.h
@@ -58,6 +58,8 @@ void hwWriteConfigBlock(void *buf, void *adr, size_t length);
 void hwWriteConfig(int adr, uint8_t value);
 uint8_t hwReadConfig(int adr);
 void hwRandomNumberInit();
+ssize_t hwGetentropy(void *__buffer, size_t __length);
+#define MY_HW_HAS_GETRANDOM
 
 #ifndef MY_SERIALDEVICE
 #define MY_SERIALDEVICE Serial
@@ -108,6 +110,20 @@ static __inline__ void __priMaskRestore(const uint32_t *priMask)
 #define MY_HW_RTC_IRQ_HANDLER RTC0_IRQHandler
 #define MY_HW_RTC_IRQN RTC0_IRQn
 #endif
+
+/** Datastructure for AES ECB unit
+ */
+typedef struct {
+	/** AES Key
+	 */
+	uint8_t key[16];
+	/** Unencrypted data
+	 */
+	uint8_t cleartext[16];
+	/** Encrypted data
+	 */
+	uint8_t ciphertext[16];
+} nrf_ecb_t;
 
 #ifndef DOXYGEN
 #define MY_CRITICAL_SECTION                                                    \


### PR DESCRIPTION
This commit changes the way random numbers are available with MySensors. It's allowed to use a fast way for random number generation, which speeds up signing and allows longer battery life time.

On my hardware, without this patch, the AVR random generator is initialized with a value around ~240-200. With this patch, the AVR platform uses a 32 Bit random seed build from a floating
analog pin. The way of the generation of this seed is FIPS 140-2 compliant on my hardware. This reduces the risk generating the same nonce twice by switching the entropy from 6 bits to 32 bits and by a different runtime of hwRandomNumberInit().

For support MCU with a fast way to generate random data, the hwGetentropy() command is now available to allow rapid generation of random data.

The ESP8266 platform uses the internal random source for randomness for hwGetentropy() and Arduino's random() function. If the random() function is not seeded, so random() returns HWRNG data: https://github.com/esp8266/Arduino/blob/4897e0006b5b0123a2fa31f67b14a3fff65ce561/cores/esp8266/WMath.cpp#L45 I have removed the seed call.

The NRF5 platform initializes the pseudo random number generator from internal hardware number generator. The internal AES-ECB unit generates random data after filling with HWRNG data by AES-CBC.

On Linux getrandom() is implemented via syscall(). I think this is required to use signing to reduce the chance of duplicated nonces.

signerAtsha204SoftGetNonce speed:
AVR = ~14000us (sha204Soft)
NRF51 = ~152us (AES-CBC), 1739us (old sha204Soft)
NRF52 = ~31us (AES-CBC), 183us (old sha204Soft)
ESP8266 = ~20us (RANDOM_REG32), 380us (old sha204Soft)

All Nonce results tested for FIPS 140-2 compliance successfully.