### PR TITLE
Let signing backend validate personalization

### DIFF
--- a/core/MySigningAtsha204Soft.cpp
+++ b/core/MySigningAtsha204Soft.cpp
@@ -103,8 +103,37 @@ bool signerAtsha204SoftInit(void)
 		_signing_node_serial_info[8] = getNodeId();
 	}
 #else
-	hwReadConfigBlock((void*)_signing_hmac_key, (void*)EEPROM_SIGNING_SOFT_HMAC_KEY_ADDRESS, 32);
-	hwReadConfigBlock((void*)_signing_node_serial_info, (void*)EEPROM_SIGNING_SOFT_SERIAL_ADDRESS, 9);
+	uint8_t buffer[32];
+	uint8_t* hash;
+	uint8_t checksum;
+
+	_signing_sha256.init();
+	hwReadConfigBlock((void*)buffer, (void*)EEPROM_SIGNING_SOFT_HMAC_KEY_ADDRESS, 32);
+	for (int i = 0; i < 32; i++) {
+		_signing_sha256.write(buffer[i]);
+	}
+	hwReadConfigBlock((void*)buffer, (void*)EEPROM_RF_ENCRYPTION_AES_KEY_ADDRESS, 16);
+	for (int i = 0; i < 16; i++) {
+		_signing_sha256.write(buffer[i]);
+	}
+	hwReadConfigBlock((void*)buffer, (void*)EEPROM_SIGNING_SOFT_SERIAL_ADDRESS, 9);
+	for (int i = 0; i < 9; i++) {
+		_signing_sha256.write(buffer[i]);
+	}
+	hash = _signing_sha256.result();
+	hwReadConfigBlock((void*)&checksum, (void*)EEPROM_PERSONALIZATION_CHECKSUM_ADDRESS, 1);
+	if (checksum != hash[0]) {
+		SIGN_DEBUG(PSTR("!SGN:PER:TAMPERED\n"));
+		init_ok = false;
+	} else {
+		SIGN_DEBUG(PSTR("SGN:PER:OK\n"));
+		init_ok = true;
+	}
+
+	if (init_ok) {
+		hwReadConfigBlock((void*)_signing_hmac_key, (void*)EEPROM_SIGNING_SOFT_HMAC_KEY_ADDRESS, 32);
+		hwReadConfigBlock((void*)_signing_node_serial_info, (void*)EEPROM_SIGNING_SOFT_SERIAL_ADDRESS, 9);
+	}
 #endif
 	if (!memcmp(_signing_node_serial_info, reset_serial, 9)) {
 		unique_id_t uniqueID;


### PR DESCRIPTION
For soft signing, let backend handle checksum verification of
personalization data. This ensures that the backends sha256 library is
used and avoids an unnecessary instanitation of the public library.
For atsha204 signing, no checksum verification is made, just chip
locking flags.

Fixes #872