### PR TITLE
memory optimizations in signing

### DIFF
--- a/core/MySigning.cpp
+++ b/core/MySigning.cpp
@@ -284,12 +284,10 @@ bool signerVerifyMsg(MyMessage &msg)
 	return verificationResult;
 }
 
-static uint8_t sha256_hash[32];
 Sha256Class _soft_sha256;
 
 void signerSha256Init(void)
 {
-	memset(sha256_hash, 0, 32);
 	_soft_sha256.init();
 }
 
@@ -302,8 +300,7 @@ void signerSha256Update(const uint8_t* data, size_t sz)
 
 uint8_t* signerSha256Final(void)
 {
-	memcpy(sha256_hash, _soft_sha256.result(), 32);
-	return sha256_hash;
+	return _soft_sha256.result();
 }
 
 int signerMemcmp(const void* a, const void* b, size_t sz)

--- a/core/MySigningAtsha204Soft.cpp
+++ b/core/MySigningAtsha204Soft.cpp
@@ -63,7 +63,7 @@ static void buf2str(const uint8_t* buf, size_t sz)
 #define SIGN_DEBUG(x,...)
 #endif
 
-Sha256Class _signing_sha256;
+HmacClass _signing_sha256;
 static unsigned long _signing_timestamp;
 static bool _signing_verification_ongoing = false;
 static uint8_t _signing_verifying_nonce[32+9+1];

--- a/drivers/ATSHA204/sha256.cpp
+++ b/drivers/ATSHA204/sha256.cpp
@@ -19,8 +19,6 @@ const uint32_t sha256K[] PROGMEM = {
 	0x748f82ee,0x78a5636f,0x84c87814,0x8cc70208,0x90befffa,0xa4506ceb,0xbef9a3f7,0xc67178f2
 };
 
-#define BUFFER_SIZE 64
-
 const uint8_t sha256InitState[] PROGMEM = {
 	0x67,0xe6,0x09,0x6a, // H0
 	0x85,0xae,0x67,0xbb, // H1
@@ -110,7 +108,7 @@ void Sha256Class::addUncounted(uint8_t data)
 {
 	buffer.b[bufferOffset ^ 3] = data;
 	bufferOffset++;
-	if (bufferOffset == BUFFER_SIZE) {
+	if (bufferOffset == BLOCK_LENGTH) {
 		hashBlock();
 		bufferOffset = 0;
 	}
@@ -166,9 +164,6 @@ uint8_t* Sha256Class::result(void)
 
 #define HMAC_IPAD 0x36
 #define HMAC_OPAD 0x5c
-
-uint8_t keyBuffer[BLOCK_LENGTH]; // K0 in FIPS-198a
-uint8_t innerHash[HASH_LENGTH];
 
 void Sha256Class::initHmac(const uint8_t* key, int keyLength)
 {

--- a/drivers/ATSHA204/sha256.cpp
+++ b/drivers/ATSHA204/sha256.cpp
@@ -165,7 +165,7 @@ uint8_t* Sha256Class::result(void)
 #define HMAC_IPAD 0x36
 #define HMAC_OPAD 0x5c
 
-void Sha256Class::initHmac(const uint8_t* key, int keyLength)
+void HmacClass::initHmac(const uint8_t* key, int keyLength)
 {
 	uint8_t i;
 	memset(keyBuffer,0,BLOCK_LENGTH);
@@ -187,7 +187,7 @@ void Sha256Class::initHmac(const uint8_t* key, int keyLength)
 	}
 }
 
-uint8_t* Sha256Class::resultHmac(void)
+uint8_t* HmacClass::resultHmac(void)
 {
 	uint8_t i;
 	// Complete inner hash

--- a/drivers/ATSHA204/sha256.h
+++ b/drivers/ATSHA204/sha256.h
@@ -21,9 +21,7 @@ class Sha256Class
 public:
 	Sha256Class(); // Constructor
 	void init(void);
-	void initHmac(const uint8_t* secret, int secretLength);
 	uint8_t* result(void);
-	uint8_t* resultHmac(void);
 	void write(uint8_t);
 private:
 	void pad();
@@ -34,6 +32,14 @@ private:
 	uint8_t bufferOffset;
 	_state state;
 	uint32_t byteCount;
+};
+
+class HmacClass : public Sha256Class
+{
+public:
+	void initHmac(const uint8_t* secret, int secretLength);
+	uint8_t* resultHmac(void);
+private:
 	uint8_t keyBuffer[BLOCK_LENGTH];
 	uint8_t innerHash[HASH_LENGTH];
 };


### PR DESCRIPTION
Hi,

due to memory constraints in some of my node sketches I looked for what's actually using a lot of memory and found some of the bits in the signing code to use some quite "big" chunks. Well... "big" in relation to the 2k total an Arduino has.

While my current need is addressed by #872 and #873, Patrick suggested that upcoming changes might reintroduce the extra memory consumption.

So, I looked for further chances to reduce the memory usage with the public signing API being used.

The individual Ideas each have their own commit... and most notably the last commit likely isn't acceptable.

This works for me (tm)... but I might be missing bits...

Please comment if there is anything I shall change/cleanup/... or if none of the ideas are acceptable ;)

Rainer