### PR TITLE
Add progmem support for String messages

### DIFF
--- a/core/MyMessage.cpp
+++ b/core/MyMessage.cpp
@@ -249,6 +249,23 @@ MyMessage& MyMessage::set(const char* value)
 	return *this;
 }
 
+#if !defined(__linux__)
+MyMessage& MyMessage::set(const __FlashStringHelper* value)
+{
+	uint8_t length = value == NULL ? 0
+		: min(strlen_P(reinterpret_cast<const char *>(value)), (size_t)MAX_PAYLOAD);
+	miSetLength(length);
+	miSetPayloadType(P_STRING);
+	if (length) {
+		strncpy_P(data, reinterpret_cast<const char *>(value), length);
+	}
+	// null terminate string
+	data[length] = 0;
+	return *this;
+}
+#endif
+
+
 MyMessage& MyMessage::set(bool value)
 {
 	miSetLength(1);

--- a/core/MyMessage.h
+++ b/core/MyMessage.h
@@ -325,6 +325,9 @@ public:
 	// Setters for payload
 	MyMessage& set(void* payload, uint8_t length);
 	MyMessage& set(const char* value);
+#if !defined(__linux__)
+	MyMessage& set(const __FlashStringHelper* value);
+#endif
 	MyMessage& set(float value, uint8_t decimals);
 	MyMessage& set(bool value);
 	MyMessage& set(uint8_t value);

--- a/core/MySensorsCore.cpp
+++ b/core/MySensorsCore.cpp
@@ -358,6 +358,22 @@ bool sendSketchInfo(const char *name, const char *version, const bool ack)
 	return result;
 }
 
+#if !defined(__linux__)
+bool sendSketchInfo(const __FlashStringHelper *name, const __FlashStringHelper *version, const bool ack)
+{
+	bool result = true;
+	if (name) {
+		result &= _sendRoute(build(_msgTmp, GATEWAY_ADDRESS, NODE_SENSOR_ID, C_INTERNAL, I_SKETCH_NAME,
+		                           ack).set(name));
+	}
+	if (version) {
+		result &= _sendRoute(build(_msgTmp, GATEWAY_ADDRESS, NODE_SENSOR_ID, C_INTERNAL, I_SKETCH_VERSION,
+		                           ack).set(version));
+	}
+	return result;
+}
+#endif
+
 bool request(const uint8_t childSensorId, const uint8_t variableType, const uint8_t destination)
 {
 	return _sendRoute(build(_msgTmp, destination, childSensorId, C_REQ, variableType).set(""));

--- a/core/MySensorsCore.h
+++ b/core/MySensorsCore.h
@@ -145,6 +145,9 @@ bool present(const uint8_t sensorId, const uint8_t sensorType, const char *descr
  * @return true Returns true if message reached the first stop on its way to destination.
  */
 bool sendSketchInfo(const char *name, const char *version, const bool ack = false);
+#if !defined(__linux__)
+bool sendSketchInfo(const __FlashStringHelper *name, const __FlashStringHelper *version, const bool ack = false);
+#endif
 
 /**
 * Sends a message to gateway or one of the other nodes in the radio network


### PR DESCRIPTION
added variant of MyMessage::set and sendSketchInfo that accept a string that's stored in PROGMEM.

This avoids the need to (temporarily) store strings in memory to get them into a message and thereby saves memory.

I'm also using this to send literal error messages.

I haven't found any real cases in the MySensors tree that are using the __FlashStringHelper. If a variant similar to other progmem related functions using set_P(...) and sendSketchinfo_P(...) is preferred, please let me know.