### PR TITLE
Keep Serial from being linked when disabled

### DIFF
--- a/hal/architecture/MyHwAVR.cpp
+++ b/hal/architecture/MyHwAVR.cpp
@@ -303,6 +303,7 @@ uint16_t hwFreeMem()
 
 void hwDebugPrint(const char *fmt, ... )
 {
+#ifndef MY_DISABLED_SERIAL
 	char fmtBuffer[MY_SERIAL_OUTPUT_SIZE];
 #ifdef MY_GATEWAY_FEATURE
 	// prepend debug message to be handled correctly by controller (C_INTERNAL, I_LOG_MESSAGE)
@@ -327,4 +328,5 @@ void hwDebugPrint(const char *fmt, ... )
 	va_end (args);
 	MY_SERIALDEVICE.print(fmtBuffer);
 	MY_SERIALDEVICE.flush();
+#endif
 }

--- a/hal/architecture/MyHwESP8266.cpp
+++ b/hal/architecture/MyHwESP8266.cpp
@@ -149,6 +149,7 @@ uint16_t hwFreeMem()
 
 void hwDebugPrint(const char *fmt, ... )
 {
+#ifndef MY_DISABLED_SERIAL
 	char fmtBuffer[MY_SERIAL_OUTPUT_SIZE];
 #ifdef MY_GATEWAY_FEATURE
 	// prepend debug message to be handled correctly by controller (C_INTERNAL, I_LOG_MESSAGE)
@@ -173,4 +174,5 @@ void hwDebugPrint(const char *fmt, ... )
 	va_end (args);
 	MY_SERIALDEVICE.print(fmtBuffer);
 	MY_SERIALDEVICE.flush();
+#endif
 }

--- a/hal/architecture/MyHwNRF5.cpp
+++ b/hal/architecture/MyHwNRF5.cpp
@@ -472,6 +472,7 @@ uint16_t hwFreeMem()
 
 void hwDebugPrint(const char *fmt, ...)
 {
+#ifndef MY_DISABLED_SERIAL
 	char fmtBuffer[MY_SERIAL_OUTPUT_SIZE];
 #ifdef MY_GATEWAY_FEATURE
 	// prepend debug message to be handled correctly by controller (C_INTERNAL, I_LOG_MESSAGE)
@@ -496,4 +497,5 @@ void hwDebugPrint(const char *fmt, ...)
 	va_end (args);
 	MY_SERIALDEVICE.print(fmtBuffer);
 	MY_SERIALDEVICE.flush();
+#endif
 }

--- a/hal/architecture/MyHwSAMD.cpp
+++ b/hal/architecture/MyHwSAMD.cpp
@@ -181,6 +181,7 @@ uint16_t hwFreeMem()
 
 void hwDebugPrint(const char *fmt, ... )
 {
+#ifndef MY_DISABLED_SERIAL
 	if (MY_SERIALDEVICE) {
 		char fmtBuffer[MY_SERIAL_OUTPUT_SIZE];
 #ifdef MY_GATEWAY_FEATURE
@@ -207,4 +208,5 @@ void hwDebugPrint(const char *fmt, ... )
 		MY_SERIALDEVICE.print(fmtBuffer);
 		//	MY_SERIALDEVICE.flush();
 	}
+#endif
 }

--- a/hal/architecture/MyHwSTM32F1.cpp
+++ b/hal/architecture/MyHwSTM32F1.cpp
@@ -169,6 +169,7 @@ uint16_t hwFreeMem()
 
 void hwDebugPrint(const char *fmt, ...)
 {
+#ifndef MY_DISABLED_SERIAL
 	char fmtBuffer[MY_SERIAL_OUTPUT_SIZE];
 #ifdef MY_GATEWAY_FEATURE
 	// prepend debug message to be handled correctly by controller (C_INTERNAL, I_LOG_MESSAGE)
@@ -195,4 +196,5 @@ void hwDebugPrint(const char *fmt, ...)
 	// Disable flush since current STM32duino implementation performs a reset
 	// instead of an actual flush
 	//MY_SERIALDEVICE.flush();
+#endif
 }

--- a/hal/architecture/MyHwTeensy3.cpp
+++ b/hal/architecture/MyHwTeensy3.cpp
@@ -167,6 +167,7 @@ void hwRandomNumberInit(void)
 
 void hwDebugPrint(const char *fmt, ...)
 {
+#ifndef MY_DISABLED_SERIAL
 	char fmtBuffer[MY_SERIAL_OUTPUT_SIZE];
 #ifdef MY_GATEWAY_FEATURE
 	// prepend debug message to be handled correctly by controller (C_INTERNAL, I_LOG_MESSAGE)
@@ -190,4 +191,5 @@ void hwDebugPrint(const char *fmt, ...)
 #endif
 	va_end(args);
 	MY_SERIALDEVICE.print(fmtBuffer);
+#endif
 }


### PR DESCRIPTION
Even with MY_DISABLED_SERIAL defined, the linker is still adding the Serial
object to the binary.

That's because a) the MySensors *.cpp files are actually included into
the sketch and compiled as part of it (and not compiled separately and
then linked) and b) due the the default(?) behavior of the linker
(https://github.com/arduino/Arduino/issues/4579).