### PR TITLE
Use bool instead of boolean in drivers

### DIFF
--- a/drivers/Linux/Arduino.h
+++ b/drivers/Linux/Arduino.h
@@ -99,7 +99,6 @@ using std::min;
 using std::max;
 using std::abs;
 
-typedef bool boolean;
 typedef uint8_t byte;
 typedef string String;
 typedef char __FlashStringHelper;

--- a/drivers/Linux/Stream.cpp
+++ b/drivers/Linux/Stream.cpp
@@ -152,7 +152,7 @@ long Stream::parseInt()
 // this allows format characters (typically commas) in values to be ignored
 long Stream::parseInt(char skipChar)
 {
-	boolean isNegative = false;
+	bool isNegative = false;
 	long value = 0;
 	int c;
 
@@ -190,8 +190,8 @@ float Stream::parseFloat()
 // this allows format characters (typically commas) in values to be ignored
 float Stream::parseFloat(char skipChar)
 {
-	boolean isNegative = false;
-	boolean isFraction = false;
+	bool isNegative = false;
+	bool isFraction = false;
 	long value = 0;
 	int c;
 	float fraction = 1.0;

--- a/drivers/PubSubClient/PubSubClient.cpp
+++ b/drivers/PubSubClient/PubSubClient.cpp
@@ -119,24 +119,24 @@ PubSubClient::PubSubClient(const char* domain, uint16_t port, MQTT_CALLBACK_SIGN
 	setStream(stream);
 }
 
-boolean PubSubClient::connect(const char *id)
+bool PubSubClient::connect(const char *id)
 {
 	return connect(id,NULL,NULL,0,0,0,0);
 }
 
-boolean PubSubClient::connect(const char *id, const char *user, const char *pass)
+bool PubSubClient::connect(const char *id, const char *user, const char *pass)
 {
 	return connect(id,user,pass,0,0,0,0);
 }
 
-boolean PubSubClient::connect(const char *id, const char* willTopic, uint8_t willQos,
-                              boolean willRetain, const char* willMessage)
+bool PubSubClient::connect(const char *id, const char* willTopic, uint8_t willQos,
+                           bool willRetain, const char* willMessage)
 {
 	return connect(id,NULL,NULL,willTopic,willQos,willRetain,willMessage);
 }
 
-boolean PubSubClient::connect(const char *id, const char *user, const char *pass,
-                              const char* willTopic, uint8_t willQos, boolean willRetain, const char* willMessage)
+bool PubSubClient::connect(const char *id, const char *user, const char *pass,
+                           const char* willTopic, uint8_t willQos, bool willRetain, const char* willMessage)
 {
 	if (!connected()) {
 		int result = 0;
@@ -230,7 +230,7 @@ boolean PubSubClient::connect(const char *id, const char *user, const char *pass
 }
 
 // reads a byte into result
-boolean PubSubClient::readByte(uint8_t * result)
+bool PubSubClient::readByte(uint8_t * result)
 {
 	uint32_t previousMillis = millis();
 	while(!_client->available()) {
@@ -244,7 +244,7 @@ boolean PubSubClient::readByte(uint8_t * result)
 }
 
 // reads a byte into result[*index] and increments index
-boolean PubSubClient::readByte(uint8_t * result, uint16_t * index)
+bool PubSubClient::readByte(uint8_t * result, uint16_t * index)
 {
 	uint16_t current_index = *index;
 	uint8_t * write_address = &(result[current_index]);
@@ -316,7 +316,7 @@ uint16_t PubSubClient::readPacket(uint8_t* lengthLength)
 	return len;
 }
 
-boolean PubSubClient::loop()
+bool PubSubClient::loop()
 {
 	if (connected()) {
 		unsigned long t = millis();
@@ -382,23 +382,23 @@ boolean PubSubClient::loop()
 	return false;
 }
 
-boolean PubSubClient::publish(const char* topic, const char* payload)
+bool PubSubClient::publish(const char* topic, const char* payload)
 {
 	return publish(topic,(const uint8_t*)payload,strlen(payload),false);
 }
 
-boolean PubSubClient::publish(const char* topic, const char* payload, boolean retained)
+bool PubSubClient::publish(const char* topic, const char* payload, bool retained)
 {
 	return publish(topic,(const uint8_t*)payload,strlen(payload),retained);
 }
 
-boolean PubSubClient::publish(const char* topic, const uint8_t* payload, unsigned int plength)
+bool PubSubClient::publish(const char* topic, const uint8_t* payload, unsigned int plength)
 {
 	return publish(topic, payload, plength, false);
 }
 
-boolean PubSubClient::publish(const char* topic, const uint8_t* payload, unsigned int plength,
-                              boolean retained)
+bool PubSubClient::publish(const char* topic, const uint8_t* payload, unsigned int plength,
+                           bool retained)
 {
 	if (connected()) {
 		if (MQTT_MAX_PACKET_SIZE < 5 + 2+strlen(topic) + plength) {
@@ -421,8 +421,8 @@ boolean PubSubClient::publish(const char* topic, const uint8_t* payload, unsigne
 	return false;
 }
 
-boolean PubSubClient::publish_P(const char* topic, const uint8_t* payload, unsigned int plength,
-                                boolean retained)
+bool PubSubClient::publish_P(const char* topic, const uint8_t* payload, unsigned int plength,
+                             bool retained)
 {
 	uint8_t llen = 0;
 	uint8_t digit;
@@ -468,7 +468,7 @@ boolean PubSubClient::publish_P(const char* topic, const uint8_t* payload, unsig
 	return rc == tlen + 4 + plength;
 }
 
-boolean PubSubClient::write(uint8_t header, uint8_t* buf, uint16_t length)
+bool PubSubClient::write(uint8_t header, uint8_t* buf, uint16_t length)
 {
 	uint8_t lenBuf[4];
 	uint8_t llen = 0;
@@ -495,7 +495,7 @@ boolean PubSubClient::write(uint8_t header, uint8_t* buf, uint16_t length)
 	uint8_t* writeBuf = buf+(4-llen);
 	uint16_t bytesRemaining = length+1+llen;  //Match the length type
 	uint8_t bytesToWrite;
-	boolean result = true;
+	bool result = true;
 	while((bytesRemaining > 0) && result) {
 		bytesToWrite = (bytesRemaining > MQTT_MAX_TRANSFER_SIZE)?MQTT_MAX_TRANSFER_SIZE:bytesRemaining;
 		rc = _client->write(writeBuf,bytesToWrite);
@@ -511,12 +511,12 @@ boolean PubSubClient::write(uint8_t header, uint8_t* buf, uint16_t length)
 #endif
 }
 
-boolean PubSubClient::subscribe(const char* topic)
+bool PubSubClient::subscribe(const char* topic)
 {
 	return subscribe(topic, 0);
 }
 
-boolean PubSubClient::subscribe(const char* topic, uint8_t qos)
+bool PubSubClient::subscribe(const char* topic, uint8_t qos)
 {
 	// original: if (qos < 0 || qos > 1) { (qos is uint8_t, hence qos < 0 impossible, tekka)
 	if (qos > 1) {
@@ -542,7 +542,7 @@ boolean PubSubClient::subscribe(const char* topic, uint8_t qos)
 	return false;
 }
 
-boolean PubSubClient::unsubscribe(const char* topic)
+bool PubSubClient::unsubscribe(const char* topic)
 {
 	if (MQTT_MAX_PACKET_SIZE < 9 + strlen(topic)) {
 		// Too long
@@ -587,9 +587,9 @@ uint16_t PubSubClient::writeString(const char* string, uint8_t* buf, uint16_t po
 }
 
 
-boolean PubSubClient::connected()
+bool PubSubClient::connected()
 {
-	boolean rc;
+	bool rc;
 	if (_client == NULL ) {
 		rc = false;
 	} else {

--- a/drivers/PubSubClient/PubSubClient.h
+++ b/drivers/PubSubClient/PubSubClient.h
@@ -92,9 +92,9 @@ private:
 	bool pingOutstanding;
 	MQTT_CALLBACK_SIGNATURE;
 	uint16_t readPacket(uint8_t*);
-	boolean readByte(uint8_t * result);
-	boolean readByte(uint8_t * result, uint16_t * index);
-	boolean write(uint8_t header, uint8_t* buf, uint16_t length);
+	bool readByte(uint8_t * result);
+	bool readByte(uint8_t * result, uint16_t * index);
+	bool write(uint8_t header, uint8_t* buf, uint16_t length);
 	uint16_t writeString(const char* string, uint8_t* buf, uint16_t pos);
 	IPAddress ip;
 	const char* domain;
@@ -127,25 +127,25 @@ public:
 	PubSubClient& setClient(Client& client); //!< setClient
 	PubSubClient& setStream(Stream& stream); //!< setStream
 
-	boolean connect(const char* id); //!< connect
-	boolean connect(const char* id, const char* user, const char* pass); //!< connect
-	boolean connect(const char* id, const char* willTopic, uint8_t willQos, boolean willRetain,
-	                const char* willMessage); //!< connect
-	boolean connect(const char* id, const char* user, const char* pass, const char* willTopic,
-	                uint8_t willQos, boolean willRetain, const char* willMessage); //!< connect
+	bool connect(const char* id); //!< connect
+	bool connect(const char* id, const char* user, const char* pass); //!< connect
+	bool connect(const char* id, const char* willTopic, uint8_t willQos, bool willRetain,
+	             const char* willMessage); //!< connect
+	bool connect(const char* id, const char* user, const char* pass, const char* willTopic,
+	             uint8_t willQos, bool willRetain, const char* willMessage); //!< connect
 	void disconnect(); //!< disconnect
-	boolean publish(const char* topic, const char* payload); //!< publish
-	boolean publish(const char* topic, const char* payload, boolean retained); //!< publish
-	boolean publish(const char* topic, const uint8_t * payload, unsigned int plength); //!< publish
-	boolean publish(const char* topic, const uint8_t * payload, unsigned int plength,
-	                boolean retained); //!< publish
-	boolean publish_P(const char* topic, const uint8_t * payload, unsigned int plength,
-	                  boolean retained); //!< publish_P
-	boolean subscribe(const char* topic); //!< subscribe
-	boolean subscribe(const char* topic, uint8_t qos); //!< subscribe
-	boolean unsubscribe(const char* topic); //!< unsubscribe
-	boolean loop(); //!< loop
-	boolean connected(); //!< connected
+	bool publish(const char* topic, const char* payload); //!< publish
+	bool publish(const char* topic, const char* payload, bool retained); //!< publish
+	bool publish(const char* topic, const uint8_t * payload, unsigned int plength); //!< publish
+	bool publish(const char* topic, const uint8_t * payload, unsigned int plength,
+	             bool retained); //!< publish
+	bool publish_P(const char* topic, const uint8_t * payload, unsigned int plength,
+	               bool retained); //!< publish_P
+	bool subscribe(const char* topic); //!< subscribe
+	bool subscribe(const char* topic, uint8_t qos); //!< subscribe
+	bool unsubscribe(const char* topic); //!< unsubscribe
+	bool loop(); //!< loop
+	bool connected(); //!< connected
 	int state(); //!< state
 };
 

--- a/drivers/SPIFlash/SPIFlash.cpp
+++ b/drivers/SPIFlash/SPIFlash.cpp
@@ -95,7 +95,7 @@ void SPIFlash::unselect()
 }
 
 /// setup SPI, read device ID etc...
-boolean SPIFlash::initialize()
+bool SPIFlash::initialize()
 {
 #if defined(SPCR) && defined(SPSR)
 	_SPCR = SPCR;
@@ -180,7 +180,7 @@ void SPIFlash::readBytes(uint32_t addr, void* buf, uint16_t len)
 }
 
 /// Send a command to the flash chip, pass TRUE for isWrite when its a write command
-void SPIFlash::command(uint8_t cmd, boolean isWrite)
+void SPIFlash::command(uint8_t cmd, bool isWrite)
 {
 #if defined(__AVR_ATmega32U4__) // Arduino Leonardo, MoteinoLeo
 	DDRB |= B00000001;            // Make sure the SS pin (PB0 - used by RFM12B on MoteinoLeo R1) is set as output HIGH!
@@ -201,7 +201,7 @@ void SPIFlash::command(uint8_t cmd, boolean isWrite)
 }
 
 /// check if the chip is busy erasing/writing
-boolean SPIFlash::busy()
+bool SPIFlash::busy()
 {
 	/*
 	select();

--- a/drivers/SPIFlash/SPIFlash.h
+++ b/drivers/SPIFlash/SPIFlash.h
@@ -117,8 +117,8 @@ class SPIFlash
 public:
 	static uint8_t UNIQUEID[8]; //!< Storage for unique identifier
 	SPIFlash(uint8_t slaveSelectPin, uint16_t jedecID=0); //!< Constructor
-	boolean initialize(); //!< setup SPI, read device ID etc...
-	void command(uint8_t cmd, boolean isWrite=
+	bool initialize(); //!< setup SPI, read device ID etc...
+	void command(uint8_t cmd, bool isWrite=
 	                 false); //!< Send a command to the flash chip, pass TRUE for isWrite when its a write command
 	uint8_t readStatus(); //!< return the STATUS register
 	uint8_t readByte(uint32_t addr); //!< read 1 byte from flash memory
@@ -126,7 +126,7 @@ public:
 	void writeByte(uint32_t addr, uint8_t byt); //!< Write 1 byte to flash memory
 	void writeBytes(uint32_t addr, const void* buf,
 	                uint16_t len); //!< write multiple bytes to flash memory (up to 64K), if define SPIFLASH_SST25TYPE is set AAI Word Programming will be used
-	boolean busy(); //!< check if the chip is busy erasing/writing
+	bool busy(); //!< check if the chip is busy erasing/writing
 	void chipErase(); //!< erase entire flash memory array
 	void blockErase4K(uint32_t address); //!< erase a 4Kbyte block
 	void blockErase32K(uint32_t address); //!< erase a 32Kbyte block

--- a/drivers/pubsubclient/CHANGES.txt
+++ b/drivers/pubsubclient/CHANGES.txt
@@ -31,7 +31,7 @@
 1.8
     * KeepAlive interval is configurable in PubSubClient.h
     * Maximum packet size is configurable in PubSubClient.h
-    * API change: Return boolean rather than int from various functions
+    * API change: Return bool rather than int from various functions
     * API change: Length parameter in message callback changed
        from int to unsigned int
     * Various internal tidy-ups around types


### PR DESCRIPTION
In the Arduino IDE, boolean is an alias for bool.
The Arduino IDE might deprecate boolean in the future. See
https://github.com/arduino/Arduino/issues/4673 for details.

Command:
find drivers -type f | xargs sed -i 's/boolean/bool/g'