### PR TITLE
Use MY_SERIALDEVICE instead of Serial in examples

### DIFF
--- a/examples/AirQualitySensor/AirQualitySensor.ino
+++ b/examples/AirQualitySensor/AirQualitySensor.ino
@@ -103,20 +103,20 @@ void presentation()
 void loop()
 {
 	uint16_t valMQ = MQGetGasPercentage(MQRead(MQ_SENSOR_ANALOG_PIN)/Ro,GAS_CO);
-	Serial.println(val);
+	MY_SERIALDEVICE.println(val);
 
-	Serial.print("LPG:");
-	Serial.print(MQGetGasPercentage(MQRead(MQ_SENSOR_ANALOG_PIN)/Ro,GAS_LPG) );
-	Serial.print( "ppm" );
-	Serial.print("    ");
-	Serial.print("CO:");
-	Serial.print(MQGetGasPercentage(MQRead(MQ_SENSOR_ANALOG_PIN)/Ro,GAS_CO) );
-	Serial.print( "ppm" );
-	Serial.print("    ");
-	Serial.print("SMOKE:");
-	Serial.print(MQGetGasPercentage(MQRead(MQ_SENSOR_ANALOG_PIN)/Ro,GAS_SMOKE) );
-	Serial.print( "ppm" );
-	Serial.print("\n");
+	MY_SERIALDEVICE.print("LPG:");
+	MY_SERIALDEVICE.print(MQGetGasPercentage(MQRead(MQ_SENSOR_ANALOG_PIN)/Ro,GAS_LPG) );
+	MY_SERIALDEVICE.print( "ppm" );
+	MY_SERIALDEVICE.print("    ");
+	MY_SERIALDEVICE.print("CO:");
+	MY_SERIALDEVICE.print(MQGetGasPercentage(MQRead(MQ_SENSOR_ANALOG_PIN)/Ro,GAS_CO) );
+	MY_SERIALDEVICE.print( "ppm" );
+	MY_SERIALDEVICE.print("    ");
+	MY_SERIALDEVICE.print("SMOKE:");
+	MY_SERIALDEVICE.print(MQGetGasPercentage(MQRead(MQ_SENSOR_ANALOG_PIN)/Ro,GAS_SMOKE) );
+	MY_SERIALDEVICE.print( "ppm" );
+	MY_SERIALDEVICE.print("\n");
 
 	if (valMQ != lastMQ) {
 		send(msg.set((int16_t)ceil(valMQ)));

--- a/examples/BatteryPoweredSensor/BatteryPoweredSensor.ino
+++ b/examples/BatteryPoweredSensor/BatteryPoweredSensor.ino
@@ -65,7 +65,7 @@ void loop()
 	// get the battery Voltage
 	int sensorValue = analogRead(BATTERY_SENSE_PIN);
 #ifdef MY_DEBUG
-	Serial.println(sensorValue);
+	MY_SERIALDEVICE.println(sensorValue);
 #endif
 
 	// 1M, 470K divider across battery and using internal ADC ref of 1.1V
@@ -77,13 +77,13 @@ void loop()
 
 #ifdef MY_DEBUG
 	float batteryV  = sensorValue * 0.003363075;
-	Serial.print("Battery Voltage: ");
-	Serial.print(batteryV);
-	Serial.println(" V");
+	MY_SERIALDEVICE.print("Battery Voltage: ");
+	MY_SERIALDEVICE.print(batteryV);
+	MY_SERIALDEVICE.println(" V");
 
-	Serial.print("Battery percent: ");
-	Serial.print(batteryPcnt);
-	Serial.println(" %");
+	MY_SERIALDEVICE.print("Battery percent: ");
+	MY_SERIALDEVICE.print(batteryPcnt);
+	MY_SERIALDEVICE.println(" %");
 #endif
 
 	if (oldBatteryPcnt != batteryPcnt) {

--- a/examples/CO2Sensor/CO2Sensor.ino
+++ b/examples/CO2Sensor/CO2Sensor.ino
@@ -85,7 +85,7 @@ void loop()
 	//wait for the pin to go HIGH and measure HIGH time
 	unsigned long duration = pulseIn(AIQ_SENSOR_ANALOG_PIN, HIGH);
 
-	//Serial.print(duration/1000); Serial.println(" ms ");
+	//MY_SERIALDEVICE.print(duration/1000); MY_SERIALDEVICE.println(" ms ");
 	//from datasheet
 	//CO2 ppm = 2000 * (Th - 2ms) / (Th + Tl - 4ms)
 	//  given Tl + Th = 1004
@@ -93,13 +93,13 @@ void loop()
 	//        = 2000 * (Th - 2ms) / (Th + 1004 - Th -4ms)
 	//        = 2000 * (Th - 2ms) / 1000 = 2 * (Th - 2ms)
 	long co2ppm = 2 * ((duration/1000) - 2);
-	//Serial.print(co2ppm);
+	//MY_SERIALDEVICE.print(co2ppm);
 	if ((co2ppm != lastAIQ)&&(abs(co2ppm-lastAIQ)>=10)) {
 		send(msg.set((long)ceil(co2ppm)));
 		lastAIQ = ceil(co2ppm);
 	}
 
-	//Serial.println();
+	//MY_SERIALDEVICE.println();
 
 	// Power down the radio.  Note that the radio will get powered back up
 	// on the next write() call.

--- a/examples/ClearEepromConfig/ClearEepromConfig.ino
+++ b/examples/ClearEepromConfig/ClearEepromConfig.ino
@@ -31,11 +31,11 @@
 void setup()
 {
 	Serial.begin(MY_BAUD_RATE);
-	Serial.println("Started clearing. Please wait...");
+	MY_SERIALDEVICE.println("Started clearing. Please wait...");
 	for (uint16_t i=0; i<EEPROM_LOCAL_CONFIG_ADDRESS; i++) {
 		hwWriteConfig(i,0xFF);
 	}
-	Serial.println("Clearing done.");
+	MY_SERIALDEVICE.println("Clearing done.");
 }
 
 void loop()

--- a/examples/DimmableLEDActuator/DimmableLEDActuator.ino
+++ b/examples/DimmableLEDActuator/DimmableLEDActuator.ino
@@ -97,10 +97,10 @@ void receive(const MyMessage &message)
 		requestedLevel = requestedLevel > 100 ? 100 : requestedLevel;
 		requestedLevel = requestedLevel < 0   ? 0   : requestedLevel;
 
-		Serial.print( "Changing level to " );
-		Serial.print( requestedLevel );
-		Serial.print( ", from " );
-		Serial.println( currentLevel );
+		MY_SERIALDEVICE.print( "Changing level to " );
+		MY_SERIALDEVICE.print( requestedLevel );
+		MY_SERIALDEVICE.print( ", from " );
+		MY_SERIALDEVICE.println( currentLevel );
 
 		fadeToLevel( requestedLevel );
 

--- a/examples/DimmableLight/DimmableLight.ino
+++ b/examples/DimmableLight/DimmableLight.ino
@@ -73,7 +73,7 @@ void setup()
 	//Here you actualy switch on/off the light with the last known dim level
 	SetCurrentState2Hardware();
 
-	Serial.println( "Node ready to receive messages..." );
+	MY_SERIALDEVICE.println( "Node ready to receive messages..." );
 }
 
 void presentation()
@@ -91,11 +91,11 @@ void loop()
 void receive(const MyMessage &message)
 {
 	if (message.type == V_LIGHT) {
-		Serial.println( "V_LIGHT command received..." );
+		MY_SERIALDEVICE.println( "V_LIGHT command received..." );
 
 		int lstate= atoi( message.data );
 		if ((lstate<0)||(lstate>1)) {
-			Serial.println( "V_LIGHT data invalid (should be 0/1)" );
+			MY_SERIALDEVICE.println( "V_LIGHT data invalid (should be 0/1)" );
 			return;
 		}
 		LastLightState=lstate;
@@ -113,10 +113,10 @@ void receive(const MyMessage &message)
 		//This means if you previously set the lights dimmer value to 50%, and turn the light ON
 		//it will do so at 50%
 	} else if (message.type == V_DIMMER) {
-		Serial.println( "V_DIMMER command received..." );
+		MY_SERIALDEVICE.println( "V_DIMMER command received..." );
 		int dimvalue= atoi( message.data );
 		if ((dimvalue<0)||(dimvalue>100)) {
-			Serial.println( "V_DIMMER data invalid (should be 0..100)" );
+			MY_SERIALDEVICE.println( "V_DIMMER data invalid (should be 0..100)" );
 			return;
 		}
 		if (dimvalue==0) {
@@ -127,7 +127,7 @@ void receive(const MyMessage &message)
 			saveState(EPROM_DIMMER_LEVEL, LastDimValue);
 		}
 	} else {
-		Serial.println( "Invalid command received..." );
+		MY_SERIALDEVICE.println( "Invalid command received..." );
 		return;
 	}
 
@@ -138,10 +138,10 @@ void receive(const MyMessage &message)
 void SetCurrentState2Hardware()
 {
 	if (LastLightState==LIGHT_OFF) {
-		Serial.println( "Light state: OFF" );
+		MY_SERIALDEVICE.println( "Light state: OFF" );
 	} else {
-		Serial.print( "Light state: ON, Level: " );
-		Serial.println( LastDimValue );
+		MY_SERIALDEVICE.print( "Light state: ON, Level: " );
+		MY_SERIALDEVICE.println( LastDimValue );
 	}
 
 	//Send current state to the controller

--- a/examples/DustSensor/DustSensor.ino
+++ b/examples/DustSensor/DustSensor.ino
@@ -87,14 +87,14 @@ void loop()
 	// Chris Nafis (c) 2012
 	dustDensity = (0.17 * calcVoltage - 0.1)*1000;
 
-	Serial.print("Raw Signal Value (0-1023): ");
-	Serial.print(voMeasured);
+	MY_SERIALDEVICE.print("Raw Signal Value (0-1023): ");
+	MY_SERIALDEVICE.print(voMeasured);
 
-	Serial.print(" - Voltage: ");
-	Serial.print(calcVoltage);
+	MY_SERIALDEVICE.print(" - Voltage: ");
+	MY_SERIALDEVICE.print(calcVoltage);
 
-	Serial.print(" - Dust Density: ");
-	Serial.println(dustDensity); // unit: ug/m3
+	MY_SERIALDEVICE.print(" - Dust Density: ");
+	MY_SERIALDEVICE.println(dustDensity); // unit: ug/m3
 
 	if (ceil(dustDensity) != lastDUST) {
 		send(dustMsg.set((int16_t)ceil(dustDensity)));

--- a/examples/DustSensorDSM/DustSensorDSM.ino
+++ b/examples/DustSensorDSM/DustSensorDSM.ino
@@ -90,9 +90,9 @@ void loop()
 
 	//get PM 2.5 density of particles over 2.5 μm.
 	concentrationPM25=(long)getPM(DUST_SENSOR_DIGITAL_PIN_PM25);
-	Serial.print("PM25: ");
-	Serial.println(concentrationPM25);
-	Serial.print("\n");
+	MY_SERIALDEVICE.print("PM25: ");
+	MY_SERIALDEVICE.println(concentrationPM25);
+	MY_SERIALDEVICE.print("\n");
 
 	if ((concentrationPM25 != lastDUSTPM25)&&(concentrationPM25>0)) {
 		send(dustMsgPM25.set((long)ceil(concentrationPM25)));
@@ -101,9 +101,9 @@ void loop()
 
 	//get PM 1.0 - density of particles over 1 μm.
 	concentrationPM10=getPM(DUST_SENSOR_DIGITAL_PIN_PM10);
-	Serial.print("PM10: ");
-	Serial.println(concentrationPM10);
-	Serial.print("\n");
+	MY_SERIALDEVICE.print("PM10: ");
+	MY_SERIALDEVICE.println(concentrationPM10);
+	MY_SERIALDEVICE.print("\n");
 	//ppmv=mg/m3 * (0.08205*Tmp)/Molecular_mass
 	//0.08205   = Universal gas constant in atm·m3/(kmol·K)
 	int temp=20; //external temperature, if you can replace this with a DHT11 or better
@@ -134,15 +134,15 @@ long getPM(int DUST_SENSOR_DIGITAL_PIN)
 		if ((endtime-starttime) > sampletime_ms) {
 			ratio = (lowpulseoccupancy-endtime+starttime)/(sampletime_ms*10.0);  // Integer percentage 0=>100
 			long concentration = 1.1*pow(ratio,3)-3.8*pow(ratio,2)+520*ratio+0.62; // using spec sheet curve
-			//Serial.print("lowpulseoccupancy:");
-			//Serial.print(lowpulseoccupancy);
-			//Serial.print("\n");
-			//Serial.print("ratio:");
-			//Serial.print(ratio);
-			//Serial.print("\n");
-			//Serial.print("DSM501A:");
-			//Serial.println(concentration);
-			//Serial.print("\n");
+			//MY_SERIALDEVICE.print("lowpulseoccupancy:");
+			//MY_SERIALDEVICE.print(lowpulseoccupancy);
+			//MY_SERIALDEVICE.print("\n");
+			//MY_SERIALDEVICE.print("ratio:");
+			//MY_SERIALDEVICE.print(ratio);
+			//MY_SERIALDEVICE.print("\n");
+			//MY_SERIALDEVICE.print("DSM501A:");
+			//MY_SERIALDEVICE.println(concentration);
+			//MY_SERIALDEVICE.print("\n");
 
 			lowpulseoccupancy = 0;
 			return(concentration);

--- a/examples/EnergyMeterPulseSensor/EnergyMeterPulseSensor.ino
+++ b/examples/EnergyMeterPulseSensor/EnergyMeterPulseSensor.ino
@@ -102,8 +102,8 @@ void loop()
 			if (watt<((unsigned long)MAX_WATT)) {
 				send(wattMsg.set(watt));  // Send watt value to gw
 			}
-			Serial.print("Watt:");
-			Serial.println(watt);
+			MY_SERIALDEVICE.print("Watt:");
+			MY_SERIALDEVICE.println(watt);
 			oldWatt = watt;
 		}
 
@@ -133,8 +133,8 @@ void receive(const MyMessage &message)
 {
 	if (message.type==V_VAR1) {
 		pulseCount = oldPulseCount = message.getLong();
-		Serial.print("Received last pulse count from gw:");
-		Serial.println(pulseCount);
+		MY_SERIALDEVICE.print("Received last pulse count from gw:");
+		MY_SERIALDEVICE.println(pulseCount);
 		pcReceived = true;
 	}
 }

--- a/examples/LightSensor/LightSensor.ino
+++ b/examples/LightSensor/LightSensor.ino
@@ -58,7 +58,7 @@ void presentation()
 void loop()
 {
 	int16_t lightLevel = (1023-analogRead(LIGHT_SENSOR_ANALOG_PIN))/10.23;
-	Serial.println(lightLevel);
+	MY_SERIALDEVICE.println(lightLevel);
 	if (lightLevel != lastLightLevel) {
 		send(msg.set(lightLevel));
 		lastLightLevel = lightLevel;

--- a/examples/MockMySensors/MockMySensors.ino
+++ b/examples/MockMySensors/MockMySensors.ino
@@ -338,22 +338,22 @@ void setup()
 	randomSeed(analogRead(0));
 
 	wait(LONG_WAIT);
-	Serial.println("GW Started");
+	MY_SERIALDEVICE.println("GW Started");
 }
 
 void presentation()
 {
 	// Send the Sketch Version Information to the Gateway
-	Serial.print("Send Sketch Info: ");
+	MY_SERIALDEVICE.print("Send Sketch Info: ");
 	sendSketchInfo(SKETCH_NAME, SKETCH_VERSION);
-	Serial.print(SKETCH_NAME);
-	Serial.println(SKETCH_VERSION);
+	MY_SERIALDEVICE.print(SKETCH_NAME);
+	MY_SERIALDEVICE.println(SKETCH_VERSION);
 	wait(LONG_WAIT);
 
 	// Get controller configuration
-	Serial.print("Get Config: ");
+	MY_SERIALDEVICE.print("Get Config: ");
 	metric = getControllerConfig().isMetric;
-	Serial.println(metric ? "Metric":"Imperial");
+	MY_SERIALDEVICE.println(metric ? "Metric":"Imperial");
 	wait(LONG_WAIT);
 
 	// Init Armed
@@ -362,173 +362,173 @@ void presentation()
 #endif
 
 	// Register all sensors to gw (they will be created as child devices)
-	Serial.println("Presenting Nodes");
-	Serial.println("________________");
+	MY_SERIALDEVICE.println("Presenting Nodes");
+	MY_SERIALDEVICE.println("________________");
 
 #ifdef ID_S_DOOR
-	Serial.println("  S_DOOR");
+	MY_SERIALDEVICE.println("  S_DOOR");
 	present(ID_S_DOOR,S_DOOR,"Outside Door");
 	wait(SHORT_WAIT);
 #endif
 
 #ifdef ID_S_MOTION
-	Serial.println("  S_MOTION");
+	MY_SERIALDEVICE.println("  S_MOTION");
 	present(ID_S_MOTION,S_MOTION,"Outside Motion");
 	wait(SHORT_WAIT);
 #endif
 
 #ifdef ID_S_SMOKE
-	Serial.println("  S_SMOKE");
+	MY_SERIALDEVICE.println("  S_SMOKE");
 	present(ID_S_SMOKE,S_SMOKE,"Kitchen Smoke");
 	wait(SHORT_WAIT);
 #endif
 
 #ifdef ID_S_LIGHT
-	Serial.println("  S_LIGHT");
+	MY_SERIALDEVICE.println("  S_LIGHT");
 	present(ID_S_LIGHT,S_LIGHT,"Hall Light");
 	wait(SHORT_WAIT);
 #endif
 
 #ifdef ID_S_DIMMER
-	Serial.println("  S_DIMMER");
+	MY_SERIALDEVICE.println("  S_DIMMER");
 	present(ID_S_DIMMER,S_DIMMER,"Living room dimmer");
 	wait(SHORT_WAIT);
 #endif
 
 #ifdef ID_S_COVER
-	Serial.println("  S_COVER");
+	MY_SERIALDEVICE.println("  S_COVER");
 	present(ID_S_COVER,S_COVER,"Window cover");
 	wait(SHORT_WAIT);
 #endif
 
 #ifdef ID_S_TEMP
-	Serial.println("  S_TEMP");
+	MY_SERIALDEVICE.println("  S_TEMP");
 	present(ID_S_TEMP,S_TEMP,"House Temperarue");
 	wait(SHORT_WAIT);
 #endif
 
 #ifdef ID_S_HUM
-	Serial.println("  S_HUM");
+	MY_SERIALDEVICE.println("  S_HUM");
 	present(ID_S_HUM,S_HUM,"Current Humidity");
 	wait(SHORT_WAIT);
 #endif
 
 #ifdef ID_S_BARO
-	Serial.println("  S_BARO");
+	MY_SERIALDEVICE.println("  S_BARO");
 	present(ID_S_BARO,S_BARO," Air pressure");
 	wait(SHORT_WAIT);
 #endif
 
 #ifdef ID_S_WIND
-	Serial.println("  S_WIND");
+	MY_SERIALDEVICE.println("  S_WIND");
 	present(ID_S_WIND,S_WIND,"Wind Station");
 	wait(SHORT_WAIT);
 #endif
 
 #ifdef ID_S_RAIN
-	Serial.println("  S_RAIN");
+	MY_SERIALDEVICE.println("  S_RAIN");
 	present(ID_S_RAIN,S_RAIN,"Rain Station");
 	wait(SHORT_WAIT);
 #endif
 
 #ifdef ID_S_UV
-	Serial.println("  S_UV");
+	MY_SERIALDEVICE.println("  S_UV");
 	present(ID_S_UV,S_UV,"Ultra Violet");
 	wait(SHORT_WAIT);
 #endif
 
 #ifdef ID_S_WEIGHT
-	Serial.println("  S_WEIGHT");
+	MY_SERIALDEVICE.println("  S_WEIGHT");
 	present(ID_S_WEIGHT,S_WEIGHT,"Outdoor Scale");
 	wait(SHORT_WAIT);
 #endif
 
 #ifdef ID_S_POWER
-	Serial.println("  S_POWER");
+	MY_SERIALDEVICE.println("  S_POWER");
 	present(ID_S_POWER,S_POWER,"Power Metric");
 	wait(SHORT_WAIT);
 #endif
 
 #ifdef ID_S_HEATER
-	Serial.println("  S_HEATER");
+	MY_SERIALDEVICE.println("  S_HEATER");
 	present(ID_S_HEATER,S_HEATER,"Garage Heater");
 	wait(SHORT_WAIT);
 #endif
 
 #ifdef ID_S_DISTANCE
-	Serial.println("  S_DISTANCE");
+	MY_SERIALDEVICE.println("  S_DISTANCE");
 	present(ID_S_DISTANCE,S_DISTANCE,"Distance Measure");
 	wait(SHORT_WAIT);
 #endif
 
 #ifdef ID_S_LIGHT_LEVEL
-	Serial.println("  S_LIGHT_LEVEL");
+	MY_SERIALDEVICE.println("  S_LIGHT_LEVEL");
 	present(ID_S_LIGHT_LEVEL,S_LIGHT_LEVEL,"Outside Light Level");
 	wait(SHORT_WAIT);
 #endif
 
 #ifdef ID_S_LOCK
-	Serial.println("  S_LOCK");
+	MY_SERIALDEVICE.println("  S_LOCK");
 	present(ID_S_LOCK,S_LOCK,"Front Door Lock");
 	wait(SHORT_WAIT);
 #endif
 
 #ifdef ID_S_IR
-	Serial.println("  S_IR");
+	MY_SERIALDEVICE.println("  S_IR");
 	present(ID_S_IR,S_IR,"Univeral Command");
 	wait(SHORT_WAIT);
 #endif
 
 #ifdef ID_S_WATER
-	Serial.println("  S_WATER");
+	MY_SERIALDEVICE.println("  S_WATER");
 	present(ID_S_WATER,S_WATER,"Water Level");
 	wait(SHORT_WAIT);
 #endif
 
 #ifdef ID_S_AIR_QUALITY
-	Serial.println("  S_AIR_QUALITY");
+	MY_SERIALDEVICE.println("  S_AIR_QUALITY");
 	present(ID_S_AIR_QUALITY,S_AIR_QUALITY,"Air Station");
 	wait(SHORT_WAIT);
 #endif
 
 #ifdef ID_S_DUST
-	Serial.println("  S_DUST");
+	MY_SERIALDEVICE.println("  S_DUST");
 	present(ID_S_DUST,S_DUST,"Dust Level");
 	wait(SHORT_WAIT);
 #endif
 
 #ifdef ID_S_SCENE_CONTROLLER
-	Serial.println("  S_SCENE_CONTROLLER");
+	MY_SERIALDEVICE.println("  S_SCENE_CONTROLLER");
 	present(ID_S_SCENE_CONTROLLER,S_SCENE_CONTROLLER,"Scene Controller");
 	wait(SHORT_WAIT);
 #endif
 
 #ifdef ID_S_RGB_LIGHT
-	Serial.println("  RGB_LIGHT");
+	MY_SERIALDEVICE.println("  RGB_LIGHT");
 	present(ID_S_RGB_LIGHT,S_RGB_LIGHT,"Mood Light");
 	wait(SHORT_WAIT);
 #endif
 
 #ifdef ID_S_RGBW_LIGHT
-	Serial.println("  RGBW_LIGHT");
+	MY_SERIALDEVICE.println("  RGBW_LIGHT");
 	present(ID_S_RGBW_LIGHT,S_RGBW_LIGHT,"Mood Light 2");
 	wait(SHORT_WAIT);
 #endif
 
 #ifdef ID_S_COLOR_SENSOR
-	Serial.println("  COLOR_SENSOR");
+	MY_SERIALDEVICE.println("  COLOR_SENSOR");
 	present(ID_S_COLOR_SENSOR,S_COLOR_SENSOR,"Hall Painting");
 	wait(SHORT_WAIT);
 #endif
 
 #ifdef ID_S_HVAC
-	Serial.println("  HVAC");
+	MY_SERIALDEVICE.println("  HVAC");
 	present(ID_S_HVAC,S_HVAC,"HVAC");
 	wait(SHORT_WAIT);
 #endif
 
 #ifdef ID_S_MULTIMETER
-	Serial.println("  MULTIMETER");
+	MY_SERIALDEVICE.println("  MULTIMETER");
 	present(ID_S_MULTIMETER,S_MULTIMETER,"Electric Staion");
 	wait(SHORT_WAIT);
 #endif
@@ -545,40 +545,40 @@ void presentation()
 #endif
 
 #ifdef ID_S_MOISTURE
-	Serial.println("  S_MOISTURE");
+	MY_SERIALDEVICE.println("  S_MOISTURE");
 	present(ID_S_MOISTURE,S_MOISTURE,"Basement Sensor");
 	wait(SHORT_WAIT);
 #endif
 
 #ifdef ID_S_CUSTOM
-	Serial.println("  S_CUSTOM");
+	MY_SERIALDEVICE.println("  S_CUSTOM");
 	present(ID_S_CUSTOM,S_CUSTOM,"Other Stuff");
 	wait(SHORT_WAIT);
 #endif
 
 
 
-	Serial.println("________________");
+	MY_SERIALDEVICE.println("________________");
 
 }
 
 void loop()
 {
-	Serial.println("");
-	Serial.println("");
-	Serial.println("");
-	Serial.println("#########################");
+	MY_SERIALDEVICE.println("");
+	MY_SERIALDEVICE.println("");
+	MY_SERIALDEVICE.println("");
+	MY_SERIALDEVICE.println("#########################");
 	randNumber=random(0,101);
 
-	Serial.print("RandomNumber:");
-	Serial.println(randNumber);
+	MY_SERIALDEVICE.print("RandomNumber:");
+	MY_SERIALDEVICE.println(randNumber);
 	// Send fake battery level
-	Serial.println("Send Battery Level");
+	MY_SERIALDEVICE.println("Send Battery Level");
 	sendBatteryLevel(randNumber);
 	wait(LONG_WAIT);
 
 	// Request time
-	Serial.println("Request Time");
+	MY_SERIALDEVICE.println("Request Time");
 	requestTime();
 	wait(LONG_WAIT);
 
@@ -716,7 +716,7 @@ void loop()
 
 	sendBatteryLevel(randNumber);
 	wait(SHORT_WAIT);
-	Serial.println("#########################");
+	MY_SERIALDEVICE.println("#########################");
 	wait(SLEEP_TIME); //sleep a bit
 }
 
@@ -724,8 +724,8 @@ void loop()
 void receiveTime(unsigned long controllerTime)
 {
 
-	Serial.print("Time value received: ");
-	Serial.println(controllerTime);
+	MY_SERIALDEVICE.print("Time value received: ");
+	MY_SERIALDEVICE.println(controllerTime);
 
 }
 
@@ -735,18 +735,18 @@ void receiveTime(unsigned long controllerTime)
 void door()
 {
 
-	Serial.print("Door is: " );
+	MY_SERIALDEVICE.print("Door is: " );
 
 	if (randNumber <= 50) {
-		Serial.println("Open");
+		MY_SERIALDEVICE.println("Open");
 		send(msg_S_DOOR_T.set((int16_t)1));
 	} else {
-		Serial.println("Closed");
+		MY_SERIALDEVICE.println("Closed");
 		send(msg_S_DOOR_T.set((int16_t)0));
 	}
 #ifdef ID_S_ARMED
-	Serial.print("System is: " );
-	Serial.println((isArmed ? "Armed":"Disarmed"));
+	MY_SERIALDEVICE.print("System is: " );
+	MY_SERIALDEVICE.println((isArmed ? "Armed":"Disarmed"));
 	send(msg_S_DOOR_A.set(isArmed));
 #endif
 }
@@ -756,19 +756,19 @@ void door()
 void motion()
 {
 
-	Serial.print("Motion is: " );
+	MY_SERIALDEVICE.print("Motion is: " );
 
 	if (randNumber <= 50) {
-		Serial.println("Active");
+		MY_SERIALDEVICE.println("Active");
 		send(msg_S_MOTION_T.set(1));
 	} else {
-		Serial.println("Quiet");
+		MY_SERIALDEVICE.println("Quiet");
 		send(msg_S_MOTION_T.set(0));
 	}
 
 #ifdef ID_S_ARMED
-	Serial.print("System is: " );
-	Serial.println((isArmed ? "Armed":"Disarmed"));
+	MY_SERIALDEVICE.print("System is: " );
+	MY_SERIALDEVICE.println((isArmed ? "Armed":"Disarmed"));
 	send(msg_S_MOTION_A.set(isArmed));
 #endif
 }
@@ -778,19 +778,19 @@ void motion()
 void smoke()
 {
 
-	Serial.print("Smoke is: " );
+	MY_SERIALDEVICE.print("Smoke is: " );
 
 	if (randNumber <= 50) {
-		Serial.println("Active");
+		MY_SERIALDEVICE.println("Active");
 		send(msg_S_SMOKE_T.set(1));
 	} else {
-		Serial.println("Quiet");
+		MY_SERIALDEVICE.println("Quiet");
 		send(msg_S_SMOKE_T.set(0));
 	}
 
 #ifdef ID_S_ARMED
-	Serial.print("System is: " );
-	Serial.println((isArmed ? "Armed":"Disarmed"));
+	MY_SERIALDEVICE.print("System is: " );
+	MY_SERIALDEVICE.println((isArmed ? "Armed":"Disarmed"));
 	send(msg_S_SMOKE_A.set(isArmed));
 #endif
 
@@ -801,8 +801,8 @@ void smoke()
 void light()
 {
 
-	Serial.print("Light is: " );
-	Serial.println((isLightOn ? "On":"Off"));
+	MY_SERIALDEVICE.print("Light is: " );
+	MY_SERIALDEVICE.println((isLightOn ? "On":"Off"));
 
 	send(msg_S_LIGHT.set(isLightOn));
 
@@ -813,8 +813,8 @@ void light()
 void dimmer()
 {
 
-	Serial.print("Dimmer is set to: " );
-	Serial.println(dimmerVal);
+	MY_SERIALDEVICE.print("Dimmer is set to: " );
+	MY_SERIALDEVICE.println(dimmerVal);
 
 	send(msg_S_DIMMER.set(dimmerVal));
 
@@ -825,16 +825,16 @@ void dimmer()
 void cover()
 {
 
-	Serial.print("Cover is : " );
+	MY_SERIALDEVICE.print("Cover is : " );
 
 	if (coverState == 1) {
-		Serial.println("Opening");
+		MY_SERIALDEVICE.println("Opening");
 		send(msg_S_COVER_U.set(1));
 	} else if (coverState == -1) {
-		Serial.println("Closing");
+		MY_SERIALDEVICE.println("Closing");
 		send(msg_S_COVER_D.set(0));
 	} else {
-		Serial.println("Idle");
+		MY_SERIALDEVICE.println("Idle");
 		send(msg_S_COVER_S.set(-1));
 	}
 	send(msg_S_COVER_V.set(coverState));
@@ -845,8 +845,8 @@ void cover()
 void temp()
 {
 
-	Serial.print("Temperature is: " );
-	Serial.println(map(randNumber,1,100,0,45));
+	MY_SERIALDEVICE.print("Temperature is: " );
+	MY_SERIALDEVICE.println(map(randNumber,1,100,0,45));
 
 	send(msg_S_TEMP.set(map(randNumber,1,100,0,45)));
 
@@ -857,8 +857,8 @@ void temp()
 void hum()
 {
 
-	Serial.print("Humitidty is: " );
-	Serial.println(randNumber);
+	MY_SERIALDEVICE.print("Humitidty is: " );
+	MY_SERIALDEVICE.println(randNumber);
 
 	send(msg_S_HUM.set(randNumber));
 
@@ -873,12 +873,12 @@ void baro()
 	long pressure = map(randNumber,1,100,870,1086);// hPa?
 	int forecast = map(randNumber,1,100,0,5);
 
-	Serial.print("Atmosferic Pressure is: " );
-	Serial.println(pressure);
+	MY_SERIALDEVICE.print("Atmosferic Pressure is: " );
+	MY_SERIALDEVICE.println(pressure);
 	send(msg_S_BARO_P.set(pressure));
 
-	Serial.print("Weather forecast: " );
-	Serial.println(weather[forecast]);
+	MY_SERIALDEVICE.print("Weather forecast: " );
+	MY_SERIALDEVICE.println(weather[forecast]);
 	send(msg_S_BARO_F.set(weather[forecast]));
 
 }
@@ -888,16 +888,16 @@ void baro()
 void wind()
 {
 
-	Serial.print("Wind Speed is: " );
-	Serial.println(randNumber);
+	MY_SERIALDEVICE.print("Wind Speed is: " );
+	MY_SERIALDEVICE.println(randNumber);
 	send(msg_S_WIND_S.set(randNumber));
 
-	Serial.print("Wind Gust is: " );
-	Serial.println(randNumber+10);
+	MY_SERIALDEVICE.print("Wind Gust is: " );
+	MY_SERIALDEVICE.println(randNumber+10);
 	send(msg_S_WIND_G.set(randNumber+10));
 
-	Serial.print("Wind Direction is: " );
-	Serial.println(map(randNumber,1,100,0,360));
+	MY_SERIALDEVICE.print("Wind Direction is: " );
+	MY_SERIALDEVICE.println(map(randNumber,1,100,0,360));
 	send(msg_S_WIND_D.set(map(randNumber,1,100,0,360)));
 
 }
@@ -907,13 +907,13 @@ void wind()
 void rain()
 {
 
-	Serial.print("Rain ammount  is: " );
-	Serial.println(randNumber);
+	MY_SERIALDEVICE.print("Rain ammount  is: " );
+	MY_SERIALDEVICE.println(randNumber);
 
 	send(msg_S_RAIN_A.set(randNumber));
 
-	Serial.print("Rain rate  is: " );
-	Serial.println(randNumber/60);
+	MY_SERIALDEVICE.print("Rain rate  is: " );
+	MY_SERIALDEVICE.println(randNumber/60);
 
 	send(msg_S_RAIN_R.set(randNumber/60,1));
 
@@ -924,8 +924,8 @@ void rain()
 void uv()
 {
 
-	Serial.print("Ultra Violet level is: " );
-	Serial.println(map(randNumber,1,100,0,15));
+	MY_SERIALDEVICE.print("Ultra Violet level is: " );
+	MY_SERIALDEVICE.println(map(randNumber,1,100,0,15));
 
 	send(msg_S_UV.set(map(randNumber,1,100,0,15)));
 
@@ -936,8 +936,8 @@ void uv()
 void weight()
 {
 
-	Serial.print("Weight is: " );
-	Serial.println(map(randNumber,1,100,0,150));
+	MY_SERIALDEVICE.print("Weight is: " );
+	MY_SERIALDEVICE.println(map(randNumber,1,100,0,150));
 
 	send(msg_S_WEIGHT.set(map(randNumber,1,100,0,150)));
 
@@ -948,12 +948,12 @@ void weight()
 void power()
 {
 
-	Serial.print("Watt is: " );
-	Serial.println(map(randNumber,1,100,0,150));
+	MY_SERIALDEVICE.print("Watt is: " );
+	MY_SERIALDEVICE.println(map(randNumber,1,100,0,150));
 	send(msg_S_POWER_W.set(map(randNumber,1,100,0,150)));
 
-	Serial.print("KWH is: " );
-	Serial.println(map(randNumber,1,100,0,150));
+	MY_SERIALDEVICE.print("KWH is: " );
+	MY_SERIALDEVICE.println(map(randNumber,1,100,0,150));
 	send(msg_S_POWER_K.set(map(randNumber,1,100,0,150)));
 
 }
@@ -967,20 +967,20 @@ void heater()
 	//  bool heater_status=false;
 	//  String heatState="Off";
 
-	Serial.print("Heater flow state is: " );
-	Serial.println(heater_flow_state);
+	MY_SERIALDEVICE.print("Heater flow state is: " );
+	MY_SERIALDEVICE.println(heater_flow_state);
 	send(msg_S_HEATER_FLOW_STATE.set(heater_flow_state.c_str()));
 
-	//  Serial.print("Heater on/off is: " );
-	//  Serial.println((heater_status==true)?"On":"Off");
+	//  MY_SERIALDEVICE.print("Heater on/off is: " );
+	//  MY_SERIALDEVICE.println((heater_status==true)?"On":"Off");
 	//  send(msg_S_HEATER_STATUS.set(heater_status));
 
-	//  Serial.print("Heater Temperature is: " );
-	//  Serial.println(heater_temp,1);
+	//  MY_SERIALDEVICE.print("Heater Temperature is: " );
+	//  MY_SERIALDEVICE.println(heater_temp,1);
 	//  send(msg_S_HEATER_TEMP.set(heater_temp,1));
 
-	Serial.print("Heater Setpoint: " );
-	Serial.println(heater_setpoint,1);
+	MY_SERIALDEVICE.print("Heater Setpoint: " );
+	MY_SERIALDEVICE.println(heater_setpoint,1);
 	send(msg_S_HEATER_SET_POINT.set(heater_setpoint,1));
 }
 #endif
@@ -989,8 +989,8 @@ void heater()
 void distance()
 {
 
-	Serial.print("Distance is: " );
-	Serial.println(map(randNumber,1,100,0,150));
+	MY_SERIALDEVICE.print("Distance is: " );
+	MY_SERIALDEVICE.println(map(randNumber,1,100,0,150));
 
 	send(msg_S_DISTANCE.set(map(randNumber,1,100,0,150)));
 
@@ -1001,8 +1001,8 @@ void distance()
 void light_level()
 {
 
-	Serial.print("Light is: " );
-	Serial.println(map(randNumber,1,100,0,150));
+	MY_SERIALDEVICE.print("Light is: " );
+	MY_SERIALDEVICE.println(map(randNumber,1,100,0,150));
 
 	send(msg_S_LIGHT_LEVEL.set(map(randNumber,1,100,0,150)));
 
@@ -1013,8 +1013,8 @@ void light_level()
 void lock()
 {
 
-	Serial.print("Lock is: " );
-	Serial.println((isLocked ? "Locked":"Unlocked"));
+	MY_SERIALDEVICE.print("Lock is: " );
+	MY_SERIALDEVICE.println((isLocked ? "Locked":"Unlocked"));
 	send(msg_S_LOCK.set(isLocked));
 
 }
@@ -1024,8 +1024,8 @@ void lock()
 void ir()
 {
 
-	Serial.print("Infrared is: " );
-	Serial.println(irVal);
+	MY_SERIALDEVICE.print("Infrared is: " );
+	MY_SERIALDEVICE.println(irVal);
 
 	send(msg_S_IR_S.set(irVal));
 	send(msg_S_IR_R.set(irVal));
@@ -1037,13 +1037,13 @@ void ir()
 void water()
 {
 
-	Serial.print("Water flow is: " );
-	Serial.println(map(randNumber,1,100,0,150));
+	MY_SERIALDEVICE.print("Water flow is: " );
+	MY_SERIALDEVICE.println(map(randNumber,1,100,0,150));
 
 	send(msg_S_WATER_F.set(map(randNumber,1,100,0,150)));
 
-	Serial.print("Water volume is: " );
-	Serial.println(map(randNumber,1,100,0,150));
+	MY_SERIALDEVICE.print("Water volume is: " );
+	MY_SERIALDEVICE.println(map(randNumber,1,100,0,150));
 
 	send(msg_S_WATER_V.set(map(randNumber,1,100,0,150)));
 
@@ -1054,8 +1054,8 @@ void water()
 void air()
 {
 
-	Serial.print("Air Quality is: " );
-	Serial.println(randNumber);
+	MY_SERIALDEVICE.print("Air Quality is: " );
+	MY_SERIALDEVICE.println(randNumber);
 
 	send(msg_S_AIR_QUALITY.set(randNumber));
 
@@ -1066,8 +1066,8 @@ void air()
 void dust()
 {
 
-	Serial.print("Dust level is: " );
-	Serial.println(randNumber);
+	MY_SERIALDEVICE.print("Dust level is: " );
+	MY_SERIALDEVICE.println(randNumber);
 
 	send(msg_S_DUST.set(randNumber));
 
@@ -1078,8 +1078,8 @@ void dust()
 void scene()
 {
 
-	Serial.print("Scene is: " );
-	Serial.println(scenes[sceneVal]);
+	MY_SERIALDEVICE.print("Scene is: " );
+	MY_SERIALDEVICE.println(scenes[sceneVal]);
 
 	if(sceneValPrevious != sceneVal) {
 		send(msg_S_SCENE_CONTROLLER_OF.set(sceneValPrevious));
@@ -1094,12 +1094,12 @@ void scene()
 void rgbLight()
 {
 
-	Serial.print("RGB Light state is: " );
-	Serial.println(rgbState);
+	MY_SERIALDEVICE.print("RGB Light state is: " );
+	MY_SERIALDEVICE.println(rgbState);
 	send(msg_S_RGB_LIGHT_V_RGB.set(rgbState.c_str()));
 
-	Serial.print("RGB Light Watt is: " );
-	Serial.println(map(randNumber,1,100,0,150));
+	MY_SERIALDEVICE.print("RGB Light Watt is: " );
+	MY_SERIALDEVICE.println(map(randNumber,1,100,0,150));
 	send(msg_S_RGB_LIGHT_V_WATT.set(map(randNumber,1,100,0,150)));
 
 }
@@ -1109,12 +1109,12 @@ void rgbLight()
 void rgbwLight()
 {
 
-	Serial.print("RGBW Light state is: " );
-	Serial.println(rgbwState);
+	MY_SERIALDEVICE.print("RGBW Light state is: " );
+	MY_SERIALDEVICE.println(rgbwState);
 	send(msg_S_RGBW_LIGHT_V_RGBW.set(rgbwState.c_str()));
 
-	Serial.print("RGBW Light Watt is: " );
-	Serial.println(map(randNumber,1,100,0,150));
+	MY_SERIALDEVICE.print("RGBW Light Watt is: " );
+	MY_SERIALDEVICE.println(map(randNumber,1,100,0,150));
 	send(msg_S_RGBW_LIGHT_V_WATT.set(map(randNumber,1,100,0,150)));
 
 }
@@ -1131,8 +1131,8 @@ void color()
 
 	colorState=String(red + green + blue);
 
-	Serial.print("Color state is: " );
-	Serial.println(colorState);
+	MY_SERIALDEVICE.print("Color state is: " );
+	MY_SERIALDEVICE.println(colorState);
 	send(msg_S_COLOR_SENSOR_V_RGB.set(colorState.c_str()));
 
 }
@@ -1148,24 +1148,24 @@ void hvac()
 	//  String hvac_FlowMode    = "Auto";
 	//  String hvac_Speed       = "Normal";
 
-	Serial.print("HVAC Set Point Heat is: " );
-	Serial.println(hvac_SetPointHeat);
+	MY_SERIALDEVICE.print("HVAC Set Point Heat is: " );
+	MY_SERIALDEVICE.println(hvac_SetPointHeat);
 	send(msg_S_HVAC_V_HVAC_SETPOINT_HEAT.set(hvac_SetPointHeat,1));
 
-	Serial.print("HVAC Set Point Cool is: " );
-	Serial.println(hvac_SetPointCool);
+	MY_SERIALDEVICE.print("HVAC Set Point Cool is: " );
+	MY_SERIALDEVICE.println(hvac_SetPointCool);
 	send(msg_S_HVAC_V_HVAC_SETPOINT_COOL.set(hvac_SetPointCool,1));
 
-	Serial.print("HVAC Flow State is: " );
-	Serial.println(hvac_FlowState);
+	MY_SERIALDEVICE.print("HVAC Flow State is: " );
+	MY_SERIALDEVICE.println(hvac_FlowState);
 	send(msg_S_HVAC_V_HVAC_FLOW_STATET.set(hvac_FlowState.c_str()));
 
-	Serial.print("HVAC Flow Mode is: " );
-	Serial.println(hvac_FlowMode);
+	MY_SERIALDEVICE.print("HVAC Flow Mode is: " );
+	MY_SERIALDEVICE.println(hvac_FlowMode);
 	send(msg_S_HVAC_V_HVAC_FLOW_MODE.set(hvac_FlowMode.c_str()));
 
-	Serial.print("HVAC Speed is: " );
-	Serial.println(hvac_Speed);
+	MY_SERIALDEVICE.print("HVAC Speed is: " );
+	MY_SERIALDEVICE.println(hvac_Speed);
 	send(msg_S_HVAC_V_HVAC_SPEED.set(hvac_Speed.c_str()));
 
 }
@@ -1178,16 +1178,16 @@ void multimeter()
 	int volt=map(randNumber,1,100,0,380);
 	int amps=map(randNumber,1,100,0,16);
 
-	Serial.print("Impedance is: " );
-	Serial.println(impedance);
+	MY_SERIALDEVICE.print("Impedance is: " );
+	MY_SERIALDEVICE.println(impedance);
 	send(msg_S_MULTIMETER_V_IMPEDANCE.set(impedance));
 
-	Serial.print("Voltage is: " );
-	Serial.println(volt);
+	MY_SERIALDEVICE.print("Voltage is: " );
+	MY_SERIALDEVICE.println(volt);
 	send(msg_S_MULTIMETER_V_VOLTAGE.set(volt));
 
-	Serial.print("Current is: " );
-	Serial.println(amps);
+	MY_SERIALDEVICE.print("Current is: " );
+	MY_SERIALDEVICE.println(amps);
 	send(msg_S_MULTIMETER_V_CURRENT.set(amps));
 
 }
@@ -1208,8 +1208,8 @@ void multimeter()
 void moisture()
 {
 
-	Serial.print("Moisture level is: " );
-	Serial.println(randNumber);
+	MY_SERIALDEVICE.print("Moisture level is: " );
+	MY_SERIALDEVICE.println(randNumber);
 
 	send(msg_S_MOISTURE.set(randNumber));
 }
@@ -1219,8 +1219,8 @@ void moisture()
 void custom()
 {
 
-	Serial.print("Custom value is: " );
-	Serial.println(randNumber);
+	MY_SERIALDEVICE.print("Custom value is: " );
+	MY_SERIALDEVICE.println(randNumber);
 
 	send(msg_S_CUSTOM_1.set(randNumber));
 	send(msg_S_CUSTOM_2.set(randNumber));
@@ -1238,10 +1238,10 @@ void receive(const MyMessage &message)
 #ifdef ID_S_ARMED
 	case V_ARMED:
 		isArmed = message.getBool();
-		Serial.print("Incoming change for ID_S_ARMED:");
-		Serial.print(message.sensor);
-		Serial.print(", New status: ");
-		Serial.println((isArmed ? "Armed":"Disarmed" ));
+		MY_SERIALDEVICE.print("Incoming change for ID_S_ARMED:");
+		MY_SERIALDEVICE.print(message.sensor);
+		MY_SERIALDEVICE.print(", New status: ");
+		MY_SERIALDEVICE.println((isArmed ? "Armed":"Disarmed" ));
 #ifdef ID_S_DOOR
 		door();//temp ack for door
 #endif
@@ -1259,20 +1259,20 @@ void receive(const MyMessage &message)
 #ifdef ID_S_LIGHT
 		if(message.sensor==ID_S_LIGHT) {
 			isLightOn =  message.getBool();
-			Serial.print("Incoming change for ID_S_LIGHT:");
-			Serial.print(message.sensor);
-			Serial.print(", New status: ");
-			Serial.println((isLightOn ? "On":"Off"));
+			MY_SERIALDEVICE.print("Incoming change for ID_S_LIGHT:");
+			MY_SERIALDEVICE.print(message.sensor);
+			MY_SERIALDEVICE.print(", New status: ");
+			MY_SERIALDEVICE.println((isLightOn ? "On":"Off"));
 			light(); // temp ack
 		}
 #endif
 		//    #ifdef ID_S_HEATER
 		//        if(message.sensor == ID_S_HEATER){
 		//          heater_status = message.getBool();
-		//          Serial.print("Incoming change for ID_S_HEATER:");
-		//          Serial.print(message.sensor);
-		//          Serial.print(", New status: ");
-		//          Serial.println(heater_status);
+		//          MY_SERIALDEVICE.print("Incoming change for ID_S_HEATER:");
+		//          MY_SERIALDEVICE.print(message.sensor);
+		//          MY_SERIALDEVICE.print(", New status: ");
+		//          MY_SERIALDEVICE.println(heater_status);
 		//          heater();//temp ack
 		//        }
 		//    #endif
@@ -1282,14 +1282,14 @@ void receive(const MyMessage &message)
 #ifdef ID_S_DIMMER
 	case V_DIMMER:
 		if ((message.getInt()<0)||(message.getInt()>100)) {
-			Serial.println( "V_DIMMER data invalid (should be 0..100)" );
+			MY_SERIALDEVICE.println( "V_DIMMER data invalid (should be 0..100)" );
 			break;
 		}
 		dimmerVal= message.getInt();
-		Serial.print("Incoming change for ID_S_DIMMER:");
-		Serial.print(message.sensor);
-		Serial.print(", New status: ");
-		Serial.println(message.getInt());
+		MY_SERIALDEVICE.print("Incoming change for ID_S_DIMMER:");
+		MY_SERIALDEVICE.print(message.sensor);
+		MY_SERIALDEVICE.print(", New status: ");
+		MY_SERIALDEVICE.println(message.getInt());
 		dimmer();// temp ack
 		break;
 #endif
@@ -1297,28 +1297,28 @@ void receive(const MyMessage &message)
 #ifdef ID_S_COVER
 	case V_UP:
 		coverState=1;
-		Serial.print("Incoming change for ID_S_COVER:");
-		Serial.print(message.sensor);
-		Serial.print(", New status: ");
-		Serial.println("V_UP");
+		MY_SERIALDEVICE.print("Incoming change for ID_S_COVER:");
+		MY_SERIALDEVICE.print(message.sensor);
+		MY_SERIALDEVICE.print(", New status: ");
+		MY_SERIALDEVICE.println("V_UP");
 		cover(); // temp ack
 		break;
 
 	case V_DOWN:
 		coverState=-1;
-		Serial.print("Incoming change for ID_S_COVER:");
-		Serial.print(message.sensor);
-		Serial.print(", New status: ");
-		Serial.println("V_DOWN");
+		MY_SERIALDEVICE.print("Incoming change for ID_S_COVER:");
+		MY_SERIALDEVICE.print(message.sensor);
+		MY_SERIALDEVICE.print(", New status: ");
+		MY_SERIALDEVICE.println("V_DOWN");
 		cover(); //temp ack
 		break;
 
 	case V_STOP:
 		coverState=0;
-		Serial.print("Incoming change for ID_S_COVER:");
-		Serial.print(message.sensor);
-		Serial.print(", New status: ");
-		Serial.println("V_STOP");
+		MY_SERIALDEVICE.print("Incoming change for ID_S_COVER:");
+		MY_SERIALDEVICE.print(message.sensor);
+		MY_SERIALDEVICE.print(", New status: ");
+		MY_SERIALDEVICE.println("V_STOP");
 		cover(); //temp ack
 		break;
 #endif
@@ -1330,10 +1330,10 @@ void receive(const MyMessage &message)
 		if(message.sensor == ID_S_HEATER) {
 			heater_setpoint=message.getFloat();
 
-			Serial.print("Incoming set point for ID_S_HEATER:");
-			Serial.print(message.sensor);
-			Serial.print(", New status: ");
-			Serial.println(heater_setpoint,1);
+			MY_SERIALDEVICE.print("Incoming set point for ID_S_HEATER:");
+			MY_SERIALDEVICE.print(message.sensor);
+			MY_SERIALDEVICE.print(", New status: ");
+			MY_SERIALDEVICE.println(heater_setpoint,1);
 			heater();//temp ack
 		}
 #endif
@@ -1341,10 +1341,10 @@ void receive(const MyMessage &message)
 #ifdef ID_S_HVAC
 		if(message.sensor == ID_S_HVAC) {
 			hvac_SetPointHeat=message.getFloat();
-			Serial.print("Incoming set point for ID_S_HVAC:");
-			Serial.print(message.sensor);
-			Serial.print(", New status: ");
-			Serial.println(hvac_SetPointHeat,1);
+			MY_SERIALDEVICE.print("Incoming set point for ID_S_HVAC:");
+			MY_SERIALDEVICE.print(message.sensor);
+			MY_SERIALDEVICE.print(", New status: ");
+			MY_SERIALDEVICE.println(hvac_SetPointHeat,1);
 			hvac();//temp ack
 		}
 #endif
@@ -1354,10 +1354,10 @@ void receive(const MyMessage &message)
 #ifdef ID_S_HEATER
 		if(message.sensor == ID_S_HEATER) {
 			heater_flow_state=message.getString();
-			Serial.print("Incoming flow state change for ID_S_HEATER:");
-			Serial.print(message.sensor);
-			Serial.print(", New status: ");
-			Serial.println(heater_flow_state);
+			MY_SERIALDEVICE.print("Incoming flow state change for ID_S_HEATER:");
+			MY_SERIALDEVICE.print(message.sensor);
+			MY_SERIALDEVICE.print(", New status: ");
+			MY_SERIALDEVICE.println(heater_flow_state);
 			heater();//temp ack
 		}
 #endif
@@ -1366,10 +1366,10 @@ void receive(const MyMessage &message)
 		if(message.sensor == ID_S_HVAC) {
 			hvac_FlowState=message.getString();
 
-			Serial.print("Incoming set point for ID_S_HVAC:");
-			Serial.print(message.sensor);
-			Serial.print(", New status: ");
-			Serial.println(hvac_FlowState);
+			MY_SERIALDEVICE.print("Incoming set point for ID_S_HVAC:");
+			MY_SERIALDEVICE.print(message.sensor);
+			MY_SERIALDEVICE.print(", New status: ");
+			MY_SERIALDEVICE.println(hvac_FlowState);
 			hvac();//temp ack
 		}
 #endif
@@ -1378,10 +1378,10 @@ void receive(const MyMessage &message)
 #ifdef ID_S_LOCK
 	case V_LOCK_STATUS:
 		isLocked =  message.getBool();
-		Serial.print("Incoming change for ID_S_LOCK:");
-		Serial.print(message.sensor);
-		Serial.print(", New status: ");
-		Serial.println(message.getBool()?"Locked":"Unlocked");
+		MY_SERIALDEVICE.print("Incoming change for ID_S_LOCK:");
+		MY_SERIALDEVICE.print(message.sensor);
+		MY_SERIALDEVICE.print(", New status: ");
+		MY_SERIALDEVICE.println(message.getBool()?"Locked":"Unlocked");
 		lock(); //temp ack
 		break;
 #endif
@@ -1389,18 +1389,18 @@ void receive(const MyMessage &message)
 #ifdef ID_S_IR
 	case V_IR_SEND:
 		irVal = message.getLong();
-		Serial.print("Incoming change for ID_S_IR:");
-		Serial.print(message.sensor);
-		Serial.print(", New status: ");
-		Serial.println(irVal);
+		MY_SERIALDEVICE.print("Incoming change for ID_S_IR:");
+		MY_SERIALDEVICE.print(message.sensor);
+		MY_SERIALDEVICE.print(", New status: ");
+		MY_SERIALDEVICE.println(irVal);
 		ir(); // temp ack
 		break;
 	case V_IR_RECEIVE:
 		irVal = message.getLong();
-		Serial.print("Incoming change for ID_S_IR:");
-		Serial.print(message.sensor);
-		Serial.print(", New status: ");
-		Serial.println(irVal);
+		MY_SERIALDEVICE.print("Incoming change for ID_S_IR:");
+		MY_SERIALDEVICE.print(message.sensor);
+		MY_SERIALDEVICE.print(", New status: ");
+		MY_SERIALDEVICE.println(irVal);
 		ir(); // temp ack
 		break;
 #endif
@@ -1408,20 +1408,20 @@ void receive(const MyMessage &message)
 #ifdef ID_S_SCENE_CONTROLLER
 	case V_SCENE_ON:
 		sceneVal = message.getInt();
-		Serial.print("Incoming change for ID_S_SCENE_CONTROLLER:");
-		Serial.print(message.sensor);
-		Serial.print(", New status: ");
-		Serial.print(scenes[sceneVal]);
-		Serial.println(" On");
+		MY_SERIALDEVICE.print("Incoming change for ID_S_SCENE_CONTROLLER:");
+		MY_SERIALDEVICE.print(message.sensor);
+		MY_SERIALDEVICE.print(", New status: ");
+		MY_SERIALDEVICE.print(scenes[sceneVal]);
+		MY_SERIALDEVICE.println(" On");
 		scene();// temp ack
 		break;
 	case V_SCENE_OFF:
 		sceneVal = message.getInt();
-		Serial.print("Incoming change for ID_S_SCENE_CONTROLLER:");
-		Serial.print(message.sensor);
-		Serial.print(", New status: ");
-		Serial.print(scenes[sceneVal]);
-		Serial.println(" Off");
+		MY_SERIALDEVICE.print("Incoming change for ID_S_SCENE_CONTROLLER:");
+		MY_SERIALDEVICE.print(message.sensor);
+		MY_SERIALDEVICE.print(", New status: ");
+		MY_SERIALDEVICE.print(scenes[sceneVal]);
+		MY_SERIALDEVICE.println(" Off");
 		scene();// temp ack
 		break;
 #endif
@@ -1429,10 +1429,10 @@ void receive(const MyMessage &message)
 #ifdef ID_S_RGB_LIGHT
 	case V_RGB:
 		rgbState=message.getString();
-		Serial.print("Incoming flow state change for ID_S_RGB_LIGHT:");
-		Serial.print(message.sensor);
-		Serial.print(", New status: ");
-		Serial.println(rgbState);
+		MY_SERIALDEVICE.print("Incoming flow state change for ID_S_RGB_LIGHT:");
+		MY_SERIALDEVICE.print(message.sensor);
+		MY_SERIALDEVICE.print(", New status: ");
+		MY_SERIALDEVICE.println(rgbState);
 		rgbLight(); // temp ack
 
 		break;
@@ -1441,10 +1441,10 @@ void receive(const MyMessage &message)
 #ifdef ID_S_RGBW_LIGHT
 	case V_RGBW:
 		rgbwState=message.getString();
-		Serial.print("Incoming flow state change for ID_S_RGBW_LIGHT:");
-		Serial.print(message.sensor);
-		Serial.print(", New status: ");
-		Serial.println(rgbwState);
+		MY_SERIALDEVICE.print("Incoming flow state change for ID_S_RGBW_LIGHT:");
+		MY_SERIALDEVICE.print(message.sensor);
+		MY_SERIALDEVICE.print(", New status: ");
+		MY_SERIALDEVICE.println(rgbwState);
 		rgbwLight();
 		break;
 #endif
@@ -1459,37 +1459,37 @@ void receive(const MyMessage &message)
 	case V_HVAC_SETPOINT_COOL:
 		hvac_SetPointCool=message.getFloat();
 
-		Serial.print("Incoming set point for ID_S_HVAC:");
-		Serial.print(message.sensor);
-		Serial.print(", New status: ");
-		Serial.println(hvac_SetPointCool,1);
+		MY_SERIALDEVICE.print("Incoming set point for ID_S_HVAC:");
+		MY_SERIALDEVICE.print(message.sensor);
+		MY_SERIALDEVICE.print(", New status: ");
+		MY_SERIALDEVICE.println(hvac_SetPointCool,1);
 		hvac();//temp ack
 		break;
 
 	case V_HVAC_FLOW_MODE:
 		hvac_Speed=message.getString();
 
-		Serial.print("Incoming set point for ID_S_HVAC:");
-		Serial.print(message.sensor);
-		Serial.print(", New status: ");
-		Serial.println(hvac_Speed);
+		MY_SERIALDEVICE.print("Incoming set point for ID_S_HVAC:");
+		MY_SERIALDEVICE.print(message.sensor);
+		MY_SERIALDEVICE.print(", New status: ");
+		MY_SERIALDEVICE.println(hvac_Speed);
 		hvac();//temp ack
 		break;
 
 	case V_HVAC_SPEED:
 		hvac_FlowMode=message.getString();
 
-		Serial.print("Incoming set point for ID_S_HVAC:");
-		Serial.print(message.sensor);
-		Serial.print(", New status: ");
-		Serial.println(hvac_FlowMode);
+		MY_SERIALDEVICE.print("Incoming set point for ID_S_HVAC:");
+		MY_SERIALDEVICE.print(message.sensor);
+		MY_SERIALDEVICE.print(", New status: ");
+		MY_SERIALDEVICE.println(hvac_FlowMode);
 		hvac();//temp ack
 		break;
 #endif
 
 	default:
-		Serial.print("Unknown/UnImplemented message type: ");
-		Serial.println(message.type);
+		MY_SERIALDEVICE.print("Unknown/UnImplemented message type: ");
+		MY_SERIALDEVICE.println(message.type);
 	}
 
 }

--- a/examples/MotionSensor/MotionSensor.ino
+++ b/examples/MotionSensor/MotionSensor.ino
@@ -64,7 +64,7 @@ void loop()
 	// Read digital motion value
 	bool tripped = digitalRead(DIGITAL_INPUT_SENSOR) == HIGH;
 
-	Serial.println(tripped);
+	MY_SERIALDEVICE.println(tripped);
 	send(msg.set(tripped?"1":"0"));  // Send tripped value to gw
 
 	// Sleep until interrupt comes in on motion sensor. Send update every two minute.

--- a/examples/MotionSensorRS485/MotionSensorRS485.ino
+++ b/examples/MotionSensorRS485/MotionSensorRS485.ino
@@ -88,7 +88,7 @@ void loop()
 	// Read digital motion value
 	bool tripped = digitalRead(DIGITAL_INPUT_SENSOR) == HIGH;
 
-	Serial.println(tripped);
+	MY_SERIALDEVICE.println(tripped);
 	send(msg.set(tripped?"1":"0"));  // Send tripped value to gw
 
 	// Sleep until interrupt comes in on motion sensor. Send update every two minute.

--- a/examples/PingPongSensor/MYSLog.h
+++ b/examples/PingPongSensor/MYSLog.h
@@ -26,7 +26,7 @@ void log(const char *fmt, ... )
 	vsnprintf(buff, sizeof(buff), fmt, args);
 	va_end (args);
 	buff[sizeof(buff)/sizeof(buff[0])-1]='\0';
-	Serial.print(buff);
+	MY_SERIALDEVICE.print(buff);
 }
 
 void log(const __FlashStringHelper *fmt, ... )
@@ -40,7 +40,7 @@ void log(const __FlashStringHelper *fmt, ... )
 	vsnprintf(buf, sizeof(buf), (const char *)fmt, args); // for the rest of the world
 #endif
 	va_end(args);
-	Serial.print(buf);
+	MY_SERIALDEVICE.print(buf);
 }
 
 #endif

--- a/examples/RelayActuator/RelayActuator.ino
+++ b/examples/RelayActuator/RelayActuator.ino
@@ -88,10 +88,10 @@ void receive(const MyMessage &message)
 		// Store state in eeprom
 		saveState(message.sensor, message.getBool());
 		// Write some debug info
-		Serial.print("Incoming change for sensor:");
-		Serial.print(message.sensor);
-		Serial.print(", New status: ");
-		Serial.println(message.getBool());
+		MY_SERIALDEVICE.print("Incoming change for sensor:");
+		MY_SERIALDEVICE.print(message.sensor);
+		MY_SERIALDEVICE.print(", New status: ");
+		MY_SERIALDEVICE.println(message.getBool());
 	}
 }
 

--- a/examples/SecretKnockSensor/SecretKnockSensor.ino
+++ b/examples/SecretKnockSensor/SecretKnockSensor.ino
@@ -188,7 +188,7 @@ void listenToSecretKnock()
 		knockSensorValue = digitalRead(knockSensor);
 
 		if (knockSensorValue == 0) {                  // Here's another knock. Save the time between knocks.
-			Serial.println("knock");
+			MY_SERIALDEVICE.println("knock");
 
 			now=millis();
 			knockReadings[currentKnockNumber] = now - startTime;
@@ -212,7 +212,7 @@ void listenToSecretKnock()
 
 		// Stop listening if there are too many knocks or there is too much time between knocks.
 	} while ((now-startTime < knockComplete) && (currentKnockNumber < maximumKnocks));
-	Serial.println("end");
+	MY_SERIALDEVICE.println("end");
 
 	//we've got our knock recorded, lets see if it's valid
 	if (programModeActive == false) {          // Only do this if we're not recording a new knock.
@@ -222,7 +222,7 @@ void listenToSecretKnock()
 			chirp(500, 1000);
 			setLockState(!lockStatus, true);
 		} else {
-			Serial.println("fail unlock");
+			MY_SERIALDEVICE.println("fail unlock");
 
 			// knock is invalid. Blink the LED as a warning to others.
 			for (i=0; i < 4; i++) {
@@ -242,9 +242,9 @@ void listenToSecretKnock()
 void setLockState(bool state, bool doSend)
 {
 	if (state) {
-		Serial.println("open lock");
+		MY_SERIALDEVICE.println("open lock");
 	} else {
-		Serial.println("close lock");
+		MY_SERIALDEVICE.println("close lock");
 	}
 	if (doSend) {
 		send(lockMsg.set(state));
@@ -403,8 +403,8 @@ void receive(const MyMessage &message)
 		setLockState(message.getBool(), false);
 
 		// Write some debug info
-		Serial.print("Incoming lock status:");
-		Serial.println(message.getBool());
+		MY_SERIALDEVICE.print("Incoming lock status:");
+		MY_SERIALDEVICE.println(message.getBool());
 	}
 }
 

--- a/examples/SecureActuator/SecureActuator.ino
+++ b/examples/SecureActuator/SecureActuator.ino
@@ -119,10 +119,10 @@ void receive(const MyMessage &message)
 		// Store state in eeprom
 		saveState(message.sensor, message.getBool());
 		// Write some debug info
-		Serial.print("Incoming change for lock:");
-		Serial.print(message.sensor);
-		Serial.print(", New status: ");
-		Serial.println(message.getBool());
+		MY_SERIALDEVICE.print("Incoming change for lock:");
+		MY_SERIALDEVICE.print(message.sensor);
+		MY_SERIALDEVICE.print(", New status: ");
+		MY_SERIALDEVICE.println(message.getBool());
 	}
 }
 /** @}*/

--- a/examples/SecurityPersonalizer/SecurityPersonalizer.ino
+++ b/examples/SecurityPersonalizer/SecurityPersonalizer.ino
@@ -469,7 +469,7 @@ void setup()
 	// Print current EEPROM
 	print_eeprom_data();
 	print_whitelisting_entry();
-	Serial.println();
+	MY_SERIALDEVICE.println();
 
 	print_ending();
 	halt(true);
@@ -483,35 +483,37 @@ void loop()
 /** @brief Print a notice and halt the execution */
 static void halt(bool success)
 {
-	Serial.println();
-	Serial.println(
+	MY_SERIALDEVICE.println();
+	MY_SERIALDEVICE.println(
 	    F("+------------------------------------------------------------------------------------+"));
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("|                                  Execution result                                  |"));
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("+------------------------------------------------------------------------------------+"));
 	if (success) {
-		Serial.println(F(
-		                   "| SUCCESS                                                                            |"));
+		MY_SERIALDEVICE.println(F(
+		                            "| SUCCESS                                                                            |"));
 	} else {
-		Serial.print(F(
-		                 "| FAILURE "));
+		MY_SERIALDEVICE.print(F(
+		                          "| FAILURE "));
 #ifdef USE_SOFT_SIGNING
-		Serial.println(F("                                                                           |"));
+		MY_SERIALDEVICE.println(
+		    F("                                                                           |"));
 #else
 		if (ret_code != SHA204_SUCCESS) {
-			Serial.print(F("(last ATSHA204A return code: 0x"));
+			MY_SERIALDEVICE.print(F("(last ATSHA204A return code: 0x"));
 			if (ret_code < 0x10) {
-				Serial.print('0'); // Because Serial.print does not 0-pad HEX
+				MY_SERIALDEVICE.print('0'); // Because MY_SERIALDEVICE.print does not 0-pad HEX
 			}
-			Serial.print(ret_code, HEX);
-			Serial.println(F(")                                         |"));
+			MY_SERIALDEVICE.print(ret_code, HEX);
+			MY_SERIALDEVICE.println(F(")                                         |"));
 		} else {
-			Serial.println(F("                                                                           |"));
+			MY_SERIALDEVICE.println(
+			    F("                                                                           |"));
 		}
 #endif
 	}
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("+------------------------------------------------------------------------------------+"));
 	while(1) {
 		doYield();
@@ -552,86 +554,87 @@ static bool generate_random_data(uint8_t* data, size_t sz)
 static void generate_keys(void)
 {
 #ifdef GENERATE_SOMETHING
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("+------------------------------------------------------------------------------------+"));
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("|                                   Key generation                                   |"));
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("+--------+--------+------------------------------------------------------------------+"));
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("| Key ID | Status | Key                                                              |"));
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("+--------+--------+------------------------------------------------------------------+"));
 #endif
 #ifdef GENERATE_HMAC_KEY
-	Serial.print(F("| HMAC   | "));
+	MY_SERIALDEVICE.print(F("| HMAC   | "));
 	if (!generate_random_data(user_hmac_key, 32)) {
 		memset(user_hmac_key, 0xFF, 32);
-		Serial.print(F("FAILED | "));
+		MY_SERIALDEVICE.print(F("FAILED | "));
 	} else {
-		Serial.print(F("OK     | "));
+		MY_SERIALDEVICE.print(F("OK     | "));
 	}
 	print_hex_buffer(user_hmac_key, 32);
-	Serial.println(F(" |"));
+	MY_SERIALDEVICE.println(F(" |"));
 #endif
 #ifdef GENERATE_AES_KEY
-	Serial.print(F("| AES    | "));
+	MY_SERIALDEVICE.print(F("| AES    | "));
 	if (!generate_random_data(user_aes_key, 16)) {
 		memset(user_aes_key, 0xFF, 16);
-		Serial.print(F("FAILED | "));
+		MY_SERIALDEVICE.print(F("FAILED | "));
 	} else {
-		Serial.print(F("OK     | "));
+		MY_SERIALDEVICE.print(F("OK     | "));
 	}
 	print_hex_buffer(user_aes_key, 16);
-	Serial.println(F("                                 |"));
+	MY_SERIALDEVICE.println(F("                                 |"));
 #endif
 #ifdef GENERATE_SOFT_SERIAL
-	Serial.print(F("| SERIAL | "));
+	MY_SERIALDEVICE.print(F("| SERIAL | "));
 	if (has_device_unique_id) {
-		Serial.println(F("N/A    | MCU has a unique serial which will be used instead.              |"));
+		MY_SERIALDEVICE.println(
+		    F("N/A    | MCU has a unique serial which will be used instead.              |"));
 	} else {
 		if (!generate_random_data(user_soft_serial, 9)) {
 			memset(user_soft_serial, 0xFF, 9);
-			Serial.print(F("FAILED | "));
+			MY_SERIALDEVICE.print(F("FAILED | "));
 		} else {
-			Serial.print(F("OK     | "));
+			MY_SERIALDEVICE.print(F("OK     | "));
 		}
 		print_hex_buffer(user_soft_serial, 9);
-		Serial.println(F("                                               |"));
+		MY_SERIALDEVICE.println(F("                                               |"));
 	}
 #endif
 #if defined(GENERATE_SOMETHING) && !defined(PERSONALIZE_SOFT_RANDOM_SERIAL)
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("+--------+--------+------------------------------------------------------------------+"));
-	Serial.println();
-	Serial.println(
+	MY_SERIALDEVICE.println();
+	MY_SERIALDEVICE.println(
 	    F("+------------------------------------------------------------------------------------+"));
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("|                                  Key copy section                                  |"));
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("+------------------------------------------------------------------------------------+"));
 #ifdef GENERATE_HMAC_KEY
-	Serial.print(F("#define MY_HMAC_KEY "));
+	MY_SERIALDEVICE.print(F("#define MY_HMAC_KEY "));
 	print_c_friendly_hex_buffer(user_hmac_key, 32);
-	Serial.println();
+	MY_SERIALDEVICE.println();
 #endif
 #ifdef GENERATE_AES_KEY
-	Serial.print(F("#define MY_AES_KEY "));
+	MY_SERIALDEVICE.print(F("#define MY_AES_KEY "));
 	print_c_friendly_hex_buffer(user_aes_key, 16);
-	Serial.println();
+	MY_SERIALDEVICE.println();
 #endif
 #ifdef GENERATE_SOFT_SERIAL
-	Serial.print(F("#define MY_SOFT_SERIAL "));
+	MY_SERIALDEVICE.print(F("#define MY_SOFT_SERIAL "));
 	print_c_friendly_hex_buffer(user_soft_serial, 9);
-	Serial.println();
+	MY_SERIALDEVICE.println();
 #endif
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("+------------------------------------------------------------------------------------+"));
-	Serial.println();
+	MY_SERIALDEVICE.println();
 #elif defined(PERSONALIZE_SOFT_RANDOM_SERIAL)
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("+--------+--------+------------------------------------------------------------------+"));
-	Serial.println();
+	MY_SERIALDEVICE.println();
 #endif
 }
 
@@ -640,44 +643,50 @@ static void generate_keys(void)
 static void	reset_eeprom(void)
 {
 	uint8_t validation_buffer[32];
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("+------------------------------------------------------------------------------------+"));
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("|                                   EEPROM reset                                     |"));
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("+--------+---------------------------------------------------------------------------+"));
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("| Key ID | Status                                                                    |"));
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("+--------+---------------------------------------------------------------------------+"));
-	Serial.print(F("| HMAC   | "));
+	MY_SERIALDEVICE.print(F("| HMAC   | "));
 	hwWriteConfigBlock((void*)reset_buffer, (void*)EEPROM_SIGNING_SOFT_HMAC_KEY_ADDRESS, 32);
 	// Validate data written
 	hwReadConfigBlock((void*)validation_buffer, (void*)EEPROM_SIGNING_SOFT_HMAC_KEY_ADDRESS, 32);
 	if (memcmp(validation_buffer, reset_buffer,	32) != 0) {
-		Serial.println(F("FAILED                                                                    |"));
+		MY_SERIALDEVICE.println(
+		    F("FAILED                                                                    |"));
 	} else {
-		Serial.println(F("OK                                                                        |"));
+		MY_SERIALDEVICE.println(
+		    F("OK                                                                        |"));
 	}
-	Serial.print(F("| AES    | "));
+	MY_SERIALDEVICE.print(F("| AES    | "));
 	hwWriteConfigBlock((void*)reset_buffer, (void*)EEPROM_RF_ENCRYPTION_AES_KEY_ADDRESS, 16);
 	// Validate data written
 	hwReadConfigBlock((void*)validation_buffer, (void*)EEPROM_RF_ENCRYPTION_AES_KEY_ADDRESS, 16);
 	if (memcmp(validation_buffer, reset_buffer,	16) != 0) {
-		Serial.println(F("FAILED                                                                    |"));
+		MY_SERIALDEVICE.println(
+		    F("FAILED                                                                    |"));
 	} else {
-		Serial.println(F("OK                                                                        |"));
+		MY_SERIALDEVICE.println(
+		    F("OK                                                                        |"));
 	}
-	Serial.print(F("| SERIAL | "));
+	MY_SERIALDEVICE.print(F("| SERIAL | "));
 	hwWriteConfigBlock((void*)reset_buffer, (void*)EEPROM_SIGNING_SOFT_SERIAL_ADDRESS, 9);
 	// Validate data written
 	hwReadConfigBlock((void*)validation_buffer, (void*)EEPROM_SIGNING_SOFT_SERIAL_ADDRESS, 9);
 	if (memcmp(validation_buffer, reset_buffer,	9) != 0) {
-		Serial.println(F("FAILED                                                                    |"));
+		MY_SERIALDEVICE.println(
+		    F("FAILED                                                                    |"));
 	} else {
-		Serial.println(F("OK                                                                        |"));
+		MY_SERIALDEVICE.println(
+		    F("OK                                                                        |"));
 	}
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("+--------+---------------------------------------------------------------------------+"));
 }
 #endif // RESET_EEPROM_PERSONALIZATION
@@ -701,58 +710,58 @@ static void write_eeprom_checksum(void)
 static void store_keys(void)
 {
 #if defined(STORE_HMAC_KEY) || defined(STORE_AES_KEY) || defined(STORE_SOFT_SERIAL)
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("+------------------------------------------------------------------------------------+"));
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("|                                    Key storage                                     |"));
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("+--------+--------+------------------------------------------------------------------+"));
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("| Key ID | Status | Key                                                              |"));
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("+--------+--------+------------------------------------------------------------------+"));
 #endif
 #ifdef STORE_HMAC_KEY
-	Serial.print(F("| HMAC   | "));
+	MY_SERIALDEVICE.print(F("| HMAC   | "));
 	if (!store_hmac_key_data(user_hmac_key)) {
-		Serial.print(F("FAILED | "));
+		MY_SERIALDEVICE.print(F("FAILED | "));
 	} else {
-		Serial.print(F("OK     | "));
+		MY_SERIALDEVICE.print(F("OK     | "));
 	}
 	print_hex_buffer(user_hmac_key, 32);
-	Serial.println(F(" |"));
+	MY_SERIALDEVICE.println(F(" |"));
 #endif
 #ifdef STORE_AES_KEY
-	Serial.print(F("| AES    | "));
+	MY_SERIALDEVICE.print(F("| AES    | "));
 	if (!store_aes_key_data(user_aes_key)) {
-		Serial.print(F("FAILED | "));
+		MY_SERIALDEVICE.print(F("FAILED | "));
 	} else {
-		Serial.print(F("OK     | "));
+		MY_SERIALDEVICE.print(F("OK     | "));
 	}
 	print_hex_buffer(user_aes_key, 16);
-	Serial.println(F("                                 |"));
+	MY_SERIALDEVICE.println(F("                                 |"));
 #endif
 #ifdef STORE_SOFT_SERIAL
-	Serial.print(F("| SERIAL | "));
+	MY_SERIALDEVICE.print(F("| SERIAL | "));
 	if (has_device_unique_id) {
 		memset(user_soft_serial, 0xFF, 9);
 	}
 	if (!store_soft_serial_data(user_soft_serial)) {
-		Serial.print(F("FAILED | "));
+		MY_SERIALDEVICE.print(F("FAILED | "));
 	} else {
-		Serial.print(F("OK     | "));
+		MY_SERIALDEVICE.print(F("OK     | "));
 	}
 	if (has_device_unique_id) {
-		Serial.println(F("EEPROM reset. MCU has a unique serial which will be used instead.|"));
+		MY_SERIALDEVICE.println(F("EEPROM reset. MCU has a unique serial which will be used instead.|"));
 	} else {
 		print_hex_buffer(user_soft_serial, 9);
-		Serial.println(F("                                               |"));
+		MY_SERIALDEVICE.println(F("                                               |"));
 	}
 #endif
 #if defined(STORE_HMAC_KEY) || defined(STORE_AES_KEY) || defined(STORE_SOFT_SERIAL)
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("+--------+--------+------------------------------------------------------------------+"));
-	Serial.println();
+	MY_SERIALDEVICE.println();
 #endif
 }
 
@@ -765,9 +774,9 @@ static void print_hex_buffer(uint8_t* data, size_t sz)
 {
 	for (size_t i=0; i<sz; i++) {
 		if (data[i] < 0x10) {
-			Serial.print('0'); // Because Serial.print does not 0-pad HEX
+			MY_SERIALDEVICE.print('0'); // Because MY_SERIALDEVICE.print does not 0-pad HEX
 		}
-		Serial.print(data[i], HEX);
+		MY_SERIALDEVICE.print(data[i], HEX);
 	}
 }
 
@@ -779,13 +788,13 @@ static void print_hex_buffer(uint8_t* data, size_t sz)
 static void print_c_friendly_hex_buffer(uint8_t* data, size_t sz)
 {
 	for (size_t i=0; i<sz; i++) {
-		Serial.print("0x");
+		MY_SERIALDEVICE.print("0x");
 		if (data[i] < 0x10) {
-			Serial.print('0'); // Because Serial.print does not 0-pad HEX
+			MY_SERIALDEVICE.print('0'); // Because MY_SERIALDEVICE.print does not 0-pad HEX
 		}
-		Serial.print(data[i], HEX);
+		MY_SERIALDEVICE.print(data[i], HEX);
 		if (i < sz-1) {
-			Serial.print(',');
+			MY_SERIALDEVICE.print(',');
 		}
 	}
 }
@@ -883,11 +892,11 @@ static void init_atsha204a_state(void)
 #ifdef LOCK_ATSHA204A_CONFIGURATION
 static void	lock_atsha204a_config(void)
 {
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("+------------------------------------------------------------------------------------+"));
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("|                           ATSHA204A configuration locking                          |"));
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("+------------------------------------------------------------------------------------+"));
 	if (lockConfig != 0x00) {
 		uint16_t crc;
@@ -898,7 +907,7 @@ static void	lock_atsha204a_config(void)
 
 		// List current configuration before attempting to lock
 #ifdef PRINT_DETAILED_ATSHA204A_CONFIG
-		Serial.println(
+		MY_SERIALDEVICE.println(
 		    F("|                             New ATSHA204A Configuration                            |"));
 		dump_detailed_atsha204a_configuration();
 #endif // PRINT_DETAILED_ATSHA204A_CONFIG
@@ -908,19 +917,19 @@ static void	lock_atsha204a_config(void)
 		while (Serial.available()) {
 			Serial.read();
 		}
-		Serial.println(
+		MY_SERIALDEVICE.println(
 		    F("| * Send SPACE character now to lock the configuration...                            |"));
 
 		while (Serial.available() == 0);
 		if (Serial.read() == ' ')
 #endif //not SKIP_UART_CONFIRMATION
 		{
-			Serial.print(F("| * Locking configuration..."));
+			MY_SERIALDEVICE.print(F("| * Locking configuration..."));
 
 			// Correct sequence, resync chip
 			ret_code = sha204.sha204c_resync(SHA204_RSP_SIZE_MAX, rx_buffer);
 			if (ret_code != SHA204_SUCCESS && ret_code != SHA204_RESYNC_WITH_WAKEUP) {
-				Serial.println(
+				MY_SERIALDEVICE.println(
 				    F("+------------------------------------------------------------------------------------+"));
 				halt(false);
 			}
@@ -930,17 +939,17 @@ static void	lock_atsha204a_config(void)
 			                                  crc, 0, NULL, 0, NULL, 0, NULL,
 			                                  LOCK_COUNT, tx_buffer, LOCK_RSP_SIZE, rx_buffer);
 			if (ret_code != SHA204_SUCCESS) {
-				Serial.println(F("Failed                                                   |"));
-				Serial.println(
+				MY_SERIALDEVICE.println(F("Failed                                                   |"));
+				MY_SERIALDEVICE.println(
 				    F("+------------------------------------------------------------------------------------+"));
 				halt(false);
 			} else {
-				Serial.println(F("Done                                                     |"));
+				MY_SERIALDEVICE.println(F("Done                                                     |"));
 
 				// Update lock flags after locking
 				ret_code = sha204.sha204m_read(tx_buffer, rx_buffer, SHA204_ZONE_CONFIG, 0x15<<2);
 				if (ret_code != SHA204_SUCCESS) {
-					Serial.println(
+					MY_SERIALDEVICE.println(
 					    F("+------------------------------------------------------------------------------------+"));
 					halt(false);
 				} else {
@@ -951,19 +960,19 @@ static void	lock_atsha204a_config(void)
 		}
 #ifndef SKIP_UART_CONFIRMATION
 		else {
-			Serial.println(
+			MY_SERIALDEVICE.println(
 			    F("| * Unexpected answer. Skipping locking.                                             |"));
-			Serial.println(
+			MY_SERIALDEVICE.println(
 			    F("+------------------------------------------------------------------------------------+"));
 		}
 #endif //not SKIP_UART_CONFIRMATION
 	} else {
-		Serial.println(
+		MY_SERIALDEVICE.println(
 		    F("| * Skipping configuration write and lock (configuration already locked).            |"));
-		Serial.println(
+		MY_SERIALDEVICE.println(
 		    F("+------------------------------------------------------------------------------------+"));
 	}
-	Serial.println();
+	MY_SERIALDEVICE.println();
 }
 
 /**
@@ -1036,7 +1045,7 @@ static uint16_t write_atsha204a_config_and_get_crc(void)
 			// All other configs are untouched
 			ret_code = sha204.sha204m_read(tx_buffer, rx_buffer, SHA204_ZONE_CONFIG, i);
 			if (ret_code != SHA204_SUCCESS) {
-				Serial.println(
+				MY_SERIALDEVICE.println(
 				    F("+------------------------------------------------------------------------------------+"));
 				halt(false);
 			}
@@ -1057,7 +1066,7 @@ static uint16_t write_atsha204a_config_and_get_crc(void)
 			                                  i >> 2, 4, config_word, 0, NULL, 0, NULL,
 			                                  WRITE_COUNT_SHORT, tx_buffer, WRITE_RSP_SIZE, rx_buffer);
 			if (ret_code != SHA204_SUCCESS) {
-				Serial.println(
+				MY_SERIALDEVICE.println(
 				    F("+------------------------------------------------------------------------------------+"));
 				halt(false);
 			}
@@ -1102,168 +1111,168 @@ static bool write_atsha204a_key(uint8_t* key)
 /** @brief Print a greeting on serial console */
 static void print_greeting(void)
 {
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("+------------------------------------------------------------------------------------+"));
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("|                           MySensors security personalizer                          |"));
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("+------------------------------------------------------------------------------------+"));
-	Serial.println();
+	MY_SERIALDEVICE.println();
 #ifdef NO_SETTINGS_DEFINED
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("+------------------------------------------------------------------------------------+"));
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("| You are running without any configuration flags set.                               |"));
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("| No changes will be made to ATSHA204A or EEPROM except for the EEPROM checksum      |"));
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("| which will be updated.                                                             |"));
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("|                                                                                    |"));
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("| If you want to personalize your device, you have two options.                      |"));
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("|                                                                                    |"));
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("| 1. a. Enable either GENERATE_KEYS_ATSHA204A or GENERATE_KEYS_SOFT                  |"));
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("|       This will generate keys for ATSHA204A or software signing.                   |"));
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("|    b. Execute the sketch. You will be guided through the steps below under         |"));
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("|       WHAT TO DO NEXT?                                                             |"));
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("|    c. Copy the generated keys and replace the topmost definitions in this file.    |"));
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("|    d. Save the sketch and then disable the flag you just enabled.                  |"));
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("|    e. Enable PERSONALIZE_ATSHA204A to personalize the ATSHA204A device.            |"));
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("|       or                                                                           |"));
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("|       Enable PERSONALIZE_SOFT to personalize the EEPROM for software signing.      |"));
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("|       If you want to use whitelisting you need to pick a unique serial number      |"));
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("|       for each device you run the sketch on and fill in MY_SOFT_SERIAL.            |"));
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("|       or                                                                           |"));
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("|       Enable PERSONALIZE_SOFT_RANDOM_SERIAL to personalzie the EEPROM and          |"));
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("|       include a new random serial number every time the sketch is executed.        |"));
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("|       Take note of each saved serial number if you plan to use whitelisting.       |"));
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("|    f. Execute the sketch on each device you want to personalize that is supposed   |"));
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("|       to communicate securely.                                                     |"));
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("|                                                                                    |"));
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("| 2. Enable any configuration flag as you see fit.                                   |"));
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("|    It is assumed that you know what you are doing.                                 |"));
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("+------------------------------------------------------------------------------------+"));
-	Serial.println();
+	MY_SERIALDEVICE.println();
 #else
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("+------------------------------------------------------------------------------------+"));
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("|                               Configuration settings                               |"));
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("+------------------------------------------------------------------------------------+"));
 #if defined(GENERATE_KEYS_ATSHA204A)
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("| * Guided key generation for ATSHA204A using ATSHA024A                              |"));
 #endif
 #if defined(GENERATE_KEYS_SOFT)
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("| * Guided key generation for EEPROM using software                                  |"));
 #endif
 #if defined(PERSONALIZE_ATSHA204A)
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("| * Guided personalization/storage of keys in ATSHA204A                              |"));
 #endif
 #if defined(PERSONALIZE_SOFT)
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("| * Guided personalization/storage of keys in EEPROM                                 |"));
 #endif
 #if defined(PERSONALIZE_SOFT_RANDOM_SERIAL)
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("| * Guided storage and generation of random serial in EEPROM                         |"));
 #endif
 #if defined(USE_SOFT_SIGNING)
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("| * Software based personalization (no ATSHA204A usage whatsoever)                   |"));
 #else
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("| * ATSHA204A based personalization                                                  |"));
 #endif
 #if defined(LOCK_ATSHA204A_CONFIGURATION)
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("| * Will lock ATSHA204A configuration                                                |"));
 #endif
 #if defined(SKIP_UART_CONFIRMATION)
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("| * Will not require any UART confirmations                                          |"));
 #endif
 #if defined(GENERATE_HMAC_KEY)
-	Serial.print(
+	MY_SERIALDEVICE.print(
 	    F("| * Will generate HMAC key using "));
 #if defined(USE_SOFT_SIGNING)
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("software                                            |"));
 #else
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("ATSHA204A                                           |"));
 #endif
 #endif
 #if defined(STORE_HMAC_KEY)
-	Serial.print(F("| * Will store HMAC key to "));
+	MY_SERIALDEVICE.print(F("| * Will store HMAC key to "));
 #if defined(USE_SOFT_SIGNING)
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("EEPROM                                                    |"));
 #else
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("ATSHA204A                                                 |"));
 #endif
 #endif
 #if defined(GENERATE_AES_KEY)
-	Serial.print(
+	MY_SERIALDEVICE.print(
 	    F("| * Will generate AES key using "));
 #if defined(USE_SOFT_SIGNING)
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("software                                             |"));
 #else
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("ATSHA204A                                            |"));
 #endif
 #endif
 #if defined(STORE_AES_KEY)
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("| * Will store AES key to EEPROM                                                     |"));
 #endif
 #if defined(GENERATE_SOFT_SERIAL)
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("| * Will generate soft serial using software                                         |"));
 #endif
 #if defined(STORE_SOFT_SERIAL)
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("| * Will store soft serial to EEPROM                                                 |"));
 #endif
 #if defined(PRINT_DETAILED_ATSHA204A_CONFIG)
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("| * Will print detailed ATSHA204A configuration                                      |"));
 #endif
 #if defined(RESET_EEPROM_PERSONALIZATION)
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("| * Will reset EEPROM personalization data                                           |"));
 #endif
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("+------------------------------------------------------------------------------------+"));
-	Serial.println();
+	MY_SERIALDEVICE.println();
 #endif // not NO_SETTINGS_DEFINED
 	probe_and_print_peripherals();
 }
@@ -1271,52 +1280,52 @@ static void print_greeting(void)
 static void print_ending(void)
 {
 #if defined(GUIDED_MODE) || defined(NO_SETTINGS_DEFINED)
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("+------------------------------------------------------------------------------------+"));
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("|                                  WHAT TO DO NEXT?                                  |"));
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("+------------------------------------------------------------------------------------+"));
 #ifdef NO_SETTINGS_DEFINED
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("| To proceed with the personalization, enable GENERATE_KEYS_ATSHA204A or             |"));
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("| GENERATE_KEYS_SOFT depending on what type of signing backend you plan to use.      |"));
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("| Both options will generate an AES key for encryption if you plan to use that.      |"));
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("| Recompile, upload and run the sketch again for further instructions.               |"));
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("+------------------------------------------------------------------------------------+"));
 #endif
 #ifdef GENERATE_KEYS_ATSHA204A
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("| To proceed with the personalization, copy the keys shown in the Key copy section,  |"));
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("| and replace the corresponding definitions in the top of the sketch, then disable   |"));
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("| GENERATE_KEYS_ATSHA204A and enable PERSONALIZE_ATSHA204A.                          |"));
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("+------------------------------------------------------------------------------------+"));
 #endif
 #ifdef GENERATE_KEYS_SOFT
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("| To proceed with the personalization, copy the keys shown in the Key copy section,  |"));
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("| and replace the corresponding definitions in the top of the sketch, then disable   |"));
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("| GENERATE_KEYS_SOFT and enable PERSONALIZE_SOFT or PERSONALIZE_SOFT_RANDOM_SERIAL.  |"));
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("+------------------------------------------------------------------------------------+"));
 #endif
 #if defined(PERSONALIZE_ATSHA204A) ||\
 	defined(PERSONALIZE_SOFT) ||\
 	defined(PERSONALIZE_SOFT_RANDOM_SERIAL)
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("| This device has now been personalized. Run this sketch with its current settings   |"));
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("| on all the devices in your network that have security enabled.                     |"));
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("+------------------------------------------------------------------------------------+"));
 #endif
 #endif // GUIDED_MODE or NO_SETTINGS_DEFINED
@@ -1326,135 +1335,136 @@ static void	probe_and_print_peripherals(void)
 {
 	unique_id_t uniqueID;
 
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("+------------------------------------------------------------------------------------+"));
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("|                           Hardware security peripherals                            |"));
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("+--------------+--------------+--------------+------------------------------+--------+"));
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("| Device       | Status       | Revision     | Serial number                | Locked |"));
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("+--------------+--------------+--------------+------------------------------+--------+"));
 #if defined(ARDUINO_ARCH_AVR)
-	Serial.print(F("| AVR          | DETECTED     | N/A          | "));
+	MY_SERIALDEVICE.print(F("| AVR          | DETECTED     | N/A          | "));
 #elif defined(ARDUINO_ARCH_ESP8266)
-	Serial.print(F("| ESP8266      | DETECTED     | N/A          | "));
+	MY_SERIALDEVICE.print(F("| ESP8266      | DETECTED     | N/A          | "));
 #elif defined(ARDUINO_ARCH_SAMD)
-	Serial.print(F("| SAMD         | DETECTED     | N/A          | "));
+	MY_SERIALDEVICE.print(F("| SAMD         | DETECTED     | N/A          | "));
 #elif defined(ARDUINO_ARCH_STM32F1)
-	Serial.print(F("| STM32F1      | DETECTED     | N/A          | "));
+	MY_SERIALDEVICE.print(F("| STM32F1      | DETECTED     | N/A          | "));
 #elif defined(__linux__)
-	Serial.print(F("| Linux        | DETECTED     | N/A          | "));
+	MY_SERIALDEVICE.print(F("| Linux        | DETECTED     | N/A          | "));
 #else
-	Serial.print(F("| Unknown      | DETECTED     | N/A          | "));
+	MY_SERIALDEVICE.print(F("| Unknown      | DETECTED     | N/A          | "));
 #endif
 	if (hwUniqueID(&uniqueID)) {
 		has_device_unique_id = true;
 		print_hex_buffer(uniqueID, 9);
-		Serial.println(F("           | N/A    |"));
+		MY_SERIALDEVICE.println(F("           | N/A    |"));
 	} else {
-		Serial.println(F("N/A (generation required)    | N/A    |"));
+		MY_SERIALDEVICE.println(F("N/A (generation required)    | N/A    |"));
 	}
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("+--------------+--------------+--------------+------------------------------+--------+"));
 #ifndef USE_SOFT_SIGNING
-	Serial.print(F("| ATSHA204A    | "));
+	MY_SERIALDEVICE.print(F("| ATSHA204A    | "));
 	ret_code = sha204.sha204c_wakeup(rx_buffer);
 	if (ret_code != SHA204_SUCCESS) {
 		ret_code = SHA204_SUCCESS; // Reset retcode to avoid false negative execution result
-		Serial.println(F("NOT DETECTED | N/A          | N/A                          | N/A    |"));
+		MY_SERIALDEVICE.println(F("NOT DETECTED | N/A          | N/A                          | N/A    |"));
 	} else {
 		uint8_t buffer[9];
-		Serial.print(F("DETECTED     | "));
+		MY_SERIALDEVICE.print(F("DETECTED     | "));
 		ret_code = sha204.sha204m_dev_rev(tx_buffer, rx_buffer);
 		if (ret_code != SHA204_SUCCESS) {
-			Serial.print(F("FAILED       | "));
+			MY_SERIALDEVICE.print(F("FAILED       | "));
 		} else {
 			print_hex_buffer(&rx_buffer[SHA204_BUFFER_POS_DATA], 4);
-			Serial.print(F("     | "));
+			MY_SERIALDEVICE.print(F("     | "));
 		}
 		if (!get_atsha204a_serial(buffer)) {
 			memset(buffer, 0xFF, 9);
-			Serial.print(F("FAILED                       | "));
+			MY_SERIALDEVICE.print(F("FAILED                       | "));
 		} else {
 			print_hex_buffer(buffer, 9);
-			Serial.print(F("           | "));
+			MY_SERIALDEVICE.print(F("           | "));
 		}
 		ret_code = sha204.sha204m_read(tx_buffer, rx_buffer, SHA204_ZONE_CONFIG, 0x15<<2);
 		if (ret_code != SHA204_SUCCESS) {
-			Serial.println("FAILED |");
+			MY_SERIALDEVICE.println("FAILED |");
 		} else {
 			if (rx_buffer[SHA204_BUFFER_POS_DATA+3] == 0x00) {
-				Serial.println("YES    |");
+				MY_SERIALDEVICE.println("YES    |");
 			} else {
-				Serial.println("NO     |");
+				MY_SERIALDEVICE.println("NO     |");
 			}
 		}
 	}
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("+--------------+--------------+--------------+------------------------------+--------+"));
 #ifdef PRINT_DETAILED_ATSHA204A_CONFIG
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("+------------------------------------------------------------------------------------+"));
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("|                          Current ATSHA204A Configuration                           |"));
 	dump_detailed_atsha204a_configuration();
 #endif
 #endif // not USE_SOFT_SIGNING
-	Serial.println();
+	MY_SERIALDEVICE.println();
 }
 
 static void print_eeprom_data(void)
 {
 	uint8_t buffer[32];
 
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("+------------------------------------------------------------------------------------+"));
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("|                                       EEPROM                                       |"));
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("+--------+--------+------------------------------------------------------------------+"));
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("| Key ID | Status | Key                                                              |"));
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("+--------+--------+------------------------------------------------------------------+"));
-	Serial.print(F("| HMAC   | "));
+	MY_SERIALDEVICE.print(F("| HMAC   | "));
 	hwReadConfigBlock((void*)buffer, (void*)EEPROM_SIGNING_SOFT_HMAC_KEY_ADDRESS, 32);
 	if (!memcmp(buffer, reset_buffer, 32)) {
-		Serial.print(F("RESET  | "));
+		MY_SERIALDEVICE.print(F("RESET  | "));
 	} else {
-		Serial.print(F("OK     | "));
+		MY_SERIALDEVICE.print(F("OK     | "));
 	}
 	print_hex_buffer(buffer, 32);
-	Serial.println(F(" |"));
-	Serial.print(F("| AES    | "));
+	MY_SERIALDEVICE.println(F(" |"));
+	MY_SERIALDEVICE.print(F("| AES    | "));
 	hwReadConfigBlock((void*)buffer, (void*)EEPROM_RF_ENCRYPTION_AES_KEY_ADDRESS, 16);
 	if (!memcmp(buffer, reset_buffer, 16)) {
-		Serial.print(F("RESET  | "));
+		MY_SERIALDEVICE.print(F("RESET  | "));
 	} else {
-		Serial.print(F("OK     | "));
+		MY_SERIALDEVICE.print(F("OK     | "));
 	}
 	print_hex_buffer(buffer, 16);
-	Serial.println(F("                                 |"));
-	Serial.print(F("| SERIAL | "));
+	MY_SERIALDEVICE.println(F("                                 |"));
+	MY_SERIALDEVICE.print(F("| SERIAL | "));
 	hwReadConfigBlock((void*)buffer, (void*)EEPROM_SIGNING_SOFT_SERIAL_ADDRESS, 9);
 	if (!memcmp(buffer, reset_buffer, 9)) {
 		if (has_device_unique_id) {
-			Serial.println(F("N/A    | Device unique serial, not stored in EEPROM                       |"));
+			MY_SERIALDEVICE.println(
+			    F("N/A    | Device unique serial, not stored in EEPROM                       |"));
 		} else {
-			Serial.print(F("RESET  | "));
+			MY_SERIALDEVICE.print(F("RESET  | "));
 			print_hex_buffer(buffer, 9);
-			Serial.println(F("                                               |"));
+			MY_SERIALDEVICE.println(F("                                               |"));
 		}
 	} else {
-		Serial.print(F("OK     | "));
+		MY_SERIALDEVICE.print(F("OK     | "));
 		print_hex_buffer(buffer, 9);
-		Serial.println(F("                                               |"));
+		MY_SERIALDEVICE.println(F("                                               |"));
 	}
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("+--------+--------+------------------------------------------------------------------+"));
-	Serial.println();
+	MY_SERIALDEVICE.println();
 }
 
 static void print_whitelisting_entry(void)
@@ -1475,16 +1485,16 @@ static void print_whitelisting_entry(void)
 		memset(buffer, 0xFF, 9);
 	}
 #endif
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("+------------------------------------------------------------------------------------+"));
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("|                      This nodes whitelist entry on other nodes                     |"));
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("+------------------------------------------------------------------------------------+"));
-	Serial.print(F("{.nodeId = <ID of this node>,.serial = {"));
+	MY_SERIALDEVICE.print(F("{.nodeId = <ID of this node>,.serial = {"));
 	print_c_friendly_hex_buffer(buffer, 9);
-	Serial.println(F("}}"));
-	Serial.println(
+	MY_SERIALDEVICE.println(F("}}"));
+	MY_SERIALDEVICE.println(
 	    F("+------------------------------------------------------------------------------------+"));
 }
 
@@ -1492,351 +1502,351 @@ static void print_whitelisting_entry(void)
 /** @brief Dump current configuration to UART */
 static void dump_detailed_atsha204a_configuration(void)
 {
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("+---------------------------------------------------------------++-------------------+"));
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("|                           Fieldname                           ||       Data        |"));
-	Serial.println(
+	MY_SERIALDEVICE.println(
 	    F("+-------------------------------+-------------------------------++---------+---------+"));
 	for (int i=0; i < 88; i += 4) {
 		ret_code = sha204.sha204m_read(tx_buffer, rx_buffer, SHA204_ZONE_CONFIG, i);
 		if (ret_code != SHA204_SUCCESS) {
-			Serial.println(
+			MY_SERIALDEVICE.println(
 			    F("+------------------------------------------------------------------------------------+"));
 			halt(false);
 		}
 		if (i == 0x00) {
-			Serial.print(F("|            SN[0:1]            |            SN[2:3]            || "));
+			MY_SERIALDEVICE.print(F("|            SN[0:1]            |            SN[2:3]            || "));
 			for (int j=0; j<4; j++) {
 				if (rx_buffer[SHA204_BUFFER_POS_DATA+j] < 0x10) {
-					Serial.print('0'); // Because Serial.print does not 0-pad HEX
+					MY_SERIALDEVICE.print('0'); // Because MY_SERIALDEVICE.print does not 0-pad HEX
 				}
-				Serial.print(rx_buffer[SHA204_BUFFER_POS_DATA+j], HEX);
+				MY_SERIALDEVICE.print(rx_buffer[SHA204_BUFFER_POS_DATA+j], HEX);
 				if (j == 1) {
-					Serial.print(F(" | "));
+					MY_SERIALDEVICE.print(F(" | "));
 				} else if (j < 3) {
-					Serial.print(F("   "));
+					MY_SERIALDEVICE.print(F("   "));
 				}
 			}
-			Serial.println(F(" |"));
-			Serial.println(
+			MY_SERIALDEVICE.println(F(" |"));
+			MY_SERIALDEVICE.println(
 			    F("+-------------------------------+-------------------------------++---------+---------+"));
 		} else if (i == 0x04) {
-			Serial.print(F("|                            Revnum                             || "));
+			MY_SERIALDEVICE.print(F("|                            Revnum                             || "));
 			for (int j=0; j<4; j++) {
 				if (rx_buffer[SHA204_BUFFER_POS_DATA+j] < 0x10) {
-					Serial.print('0'); // Because Serial.print does not 0-pad HEX
+					MY_SERIALDEVICE.print('0'); // Because MY_SERIALDEVICE.print does not 0-pad HEX
 				}
-				Serial.print(rx_buffer[SHA204_BUFFER_POS_DATA+j], HEX);
+				MY_SERIALDEVICE.print(rx_buffer[SHA204_BUFFER_POS_DATA+j], HEX);
 				if (j < 3) {
-					Serial.print(F("   "));
+					MY_SERIALDEVICE.print(F("   "));
 				}
 			}
-			Serial.println(F(" |"));
-			Serial.println(
+			MY_SERIALDEVICE.println(F(" |"));
+			MY_SERIALDEVICE.println(
 			    F("+---------------------------------------------------------------++-------------------+"));
 		} else if (i == 0x08) {
-			Serial.print(F("|                            SN[4:7]                            || "));
+			MY_SERIALDEVICE.print(F("|                            SN[4:7]                            || "));
 			for (int j=0; j<4; j++) {
 				if (rx_buffer[SHA204_BUFFER_POS_DATA+j] < 0x10) {
-					Serial.print('0'); // Because Serial.print does not 0-pad HEX
+					MY_SERIALDEVICE.print('0'); // Because MY_SERIALDEVICE.print does not 0-pad HEX
 				}
-				Serial.print(rx_buffer[SHA204_BUFFER_POS_DATA+j], HEX);
+				MY_SERIALDEVICE.print(rx_buffer[SHA204_BUFFER_POS_DATA+j], HEX);
 				if (j < 3) {
-					Serial.print(F("   "));
+					MY_SERIALDEVICE.print(F("   "));
 				}
 			}
-			Serial.println(F(" |"));
-			Serial.println(
+			MY_SERIALDEVICE.println(F(" |"));
+			MY_SERIALDEVICE.println(
 			    F("+---------------+---------------+---------------+---------------++----+----+----+----+"));
 		} else if (i == 0x0C) {
-			Serial.print(F("|     SN[8]     |  Reserved13   |   I2CEnable   |  Reserved15   || "));
+			MY_SERIALDEVICE.print(F("|     SN[8]     |  Reserved13   |   I2CEnable   |  Reserved15   || "));
 			for (int j=0; j<4; j++) {
 				if (rx_buffer[SHA204_BUFFER_POS_DATA+j] < 0x10) {
-					Serial.print('0'); // Because Serial.print does not 0-pad HEX
+					MY_SERIALDEVICE.print('0'); // Because MY_SERIALDEVICE.print does not 0-pad HEX
 				}
-				Serial.print(rx_buffer[SHA204_BUFFER_POS_DATA+j], HEX);
+				MY_SERIALDEVICE.print(rx_buffer[SHA204_BUFFER_POS_DATA+j], HEX);
 				if (j < 3) {
-					Serial.print(F(" | "));
+					MY_SERIALDEVICE.print(F(" | "));
 				} else {
-					Serial.println(F(" |"));
+					MY_SERIALDEVICE.println(F(" |"));
 				}
 			}
-			Serial.println(
+			MY_SERIALDEVICE.println(
 			    F("+---------------+---------------+---------------+---------------++----+----+----+----+"));
 		} else if (i == 0x10) {
-			Serial.print(F("|  I2CAddress   |  TempOffset   |    OTPmode    | SelectorMode  || "));
+			MY_SERIALDEVICE.print(F("|  I2CAddress   |  TempOffset   |    OTPmode    | SelectorMode  || "));
 			for (int j=0; j<4; j++) {
 				if (rx_buffer[SHA204_BUFFER_POS_DATA+j] < 0x10) {
-					Serial.print('0'); // Because Serial.print does not 0-pad HEX
+					MY_SERIALDEVICE.print('0'); // Because MY_SERIALDEVICE.print does not 0-pad HEX
 				}
-				Serial.print(rx_buffer[SHA204_BUFFER_POS_DATA+j], HEX);
+				MY_SERIALDEVICE.print(rx_buffer[SHA204_BUFFER_POS_DATA+j], HEX);
 				if (j < 3) {
-					Serial.print(F(" | "));
+					MY_SERIALDEVICE.print(F(" | "));
 				} else {
-					Serial.println(F(" |"));
+					MY_SERIALDEVICE.println(F(" |"));
 				}
 			}
-			Serial.println(
+			MY_SERIALDEVICE.println(
 			    F("+---------------+---------------+---------------+---------------++----+----+----+----+"));
 		} else if (i == 0x14) {
-			Serial.print(F("|          SlotConfig00         |         SlotConfig01          || "));
+			MY_SERIALDEVICE.print(F("|          SlotConfig00         |         SlotConfig01          || "));
 			for (int j=0; j<4; j++) {
 				if (rx_buffer[SHA204_BUFFER_POS_DATA+j] < 0x10) {
-					Serial.print('0'); // Because Serial.print does not 0-pad HEX
+					MY_SERIALDEVICE.print('0'); // Because MY_SERIALDEVICE.print does not 0-pad HEX
 				}
-				Serial.print(rx_buffer[SHA204_BUFFER_POS_DATA+j], HEX);
+				MY_SERIALDEVICE.print(rx_buffer[SHA204_BUFFER_POS_DATA+j], HEX);
 				if (j == 1) {
-					Serial.print(F(" | "));
+					MY_SERIALDEVICE.print(F(" | "));
 				} else if (j < 3) {
-					Serial.print(F("   "));
+					MY_SERIALDEVICE.print(F("   "));
 				}
 			}
-			Serial.println(F(" |"));
-			Serial.println(
+			MY_SERIALDEVICE.println(F(" |"));
+			MY_SERIALDEVICE.println(
 			    F("+-------------------------------+-------------------------------++---------+---------+"));
 		} else if (i == 0x18) {
-			Serial.print(F("|          SlotConfig02         |         SlotConfig03          || "));
+			MY_SERIALDEVICE.print(F("|          SlotConfig02         |         SlotConfig03          || "));
 			for (int j=0; j<4; j++) {
 				if (rx_buffer[SHA204_BUFFER_POS_DATA+j] < 0x10) {
-					Serial.print('0'); // Because Serial.print does not 0-pad HEX
+					MY_SERIALDEVICE.print('0'); // Because MY_SERIALDEVICE.print does not 0-pad HEX
 				}
-				Serial.print(rx_buffer[SHA204_BUFFER_POS_DATA+j], HEX);
+				MY_SERIALDEVICE.print(rx_buffer[SHA204_BUFFER_POS_DATA+j], HEX);
 				if (j == 1) {
-					Serial.print(F(" | "));
+					MY_SERIALDEVICE.print(F(" | "));
 				} else if (j < 3) {
-					Serial.print(F("   "));
+					MY_SERIALDEVICE.print(F("   "));
 				}
 			}
-			Serial.println(F(" |"));
-			Serial.println(
+			MY_SERIALDEVICE.println(F(" |"));
+			MY_SERIALDEVICE.println(
 			    F("+-------------------------------+-------------------------------++---------+---------+"));
 		} else if (i == 0x1C) {
-			Serial.print(F("|          SlotConfig04         |         SlotConfig05          || "));
+			MY_SERIALDEVICE.print(F("|          SlotConfig04         |         SlotConfig05          || "));
 			for (int j=0; j<4; j++) {
 				if (rx_buffer[SHA204_BUFFER_POS_DATA+j] < 0x10) {
-					Serial.print('0'); // Because Serial.print does not 0-pad HEX
+					MY_SERIALDEVICE.print('0'); // Because MY_SERIALDEVICE.print does not 0-pad HEX
 				}
-				Serial.print(rx_buffer[SHA204_BUFFER_POS_DATA+j], HEX);
+				MY_SERIALDEVICE.print(rx_buffer[SHA204_BUFFER_POS_DATA+j], HEX);
 				if (j == 1) {
-					Serial.print(F(" | "));
+					MY_SERIALDEVICE.print(F(" | "));
 				} else if (j < 3) {
-					Serial.print(F("   "));
+					MY_SERIALDEVICE.print(F("   "));
 				}
 			}
-			Serial.println(F(" |"));
-			Serial.println(
+			MY_SERIALDEVICE.println(F(" |"));
+			MY_SERIALDEVICE.println(
 			    F("+-------------------------------+-------------------------------++---------+---------+"));
 		} else if (i == 0x20) {
-			Serial.print(F("|          SlotConfig06         |         SlotConfig07          || "));
+			MY_SERIALDEVICE.print(F("|          SlotConfig06         |         SlotConfig07          || "));
 			for (int j=0; j<4; j++) {
 				if (rx_buffer[SHA204_BUFFER_POS_DATA+j] < 0x10) {
-					Serial.print('0'); // Because Serial.print does not 0-pad HEX
+					MY_SERIALDEVICE.print('0'); // Because MY_SERIALDEVICE.print does not 0-pad HEX
 				}
-				Serial.print(rx_buffer[SHA204_BUFFER_POS_DATA+j], HEX);
+				MY_SERIALDEVICE.print(rx_buffer[SHA204_BUFFER_POS_DATA+j], HEX);
 				if (j == 1) {
-					Serial.print(F(" | "));
+					MY_SERIALDEVICE.print(F(" | "));
 				} else if (j < 3) {
-					Serial.print(F("   "));
+					MY_SERIALDEVICE.print(F("   "));
 				}
 			}
-			Serial.println(F(" |"));
-			Serial.println(
+			MY_SERIALDEVICE.println(F(" |"));
+			MY_SERIALDEVICE.println(
 			    F("+-------------------------------+-------------------------------++---------+---------+"));
 		} else if (i == 0x24) {
-			Serial.print(F("|          SlotConfig08         |         SlotConfig09          || "));
+			MY_SERIALDEVICE.print(F("|          SlotConfig08         |         SlotConfig09          || "));
 			for (int j=0; j<4; j++) {
 				if (rx_buffer[SHA204_BUFFER_POS_DATA+j] < 0x10) {
-					Serial.print('0'); // Because Serial.print does not 0-pad HEX
+					MY_SERIALDEVICE.print('0'); // Because MY_SERIALDEVICE.print does not 0-pad HEX
 				}
-				Serial.print(rx_buffer[SHA204_BUFFER_POS_DATA+j], HEX);
+				MY_SERIALDEVICE.print(rx_buffer[SHA204_BUFFER_POS_DATA+j], HEX);
 				if (j == 1) {
-					Serial.print(F(" | "));
+					MY_SERIALDEVICE.print(F(" | "));
 				} else if (j < 3) {
-					Serial.print(F("   "));
+					MY_SERIALDEVICE.print(F("   "));
 				}
 			}
-			Serial.println(F(" |"));
-			Serial.println(
+			MY_SERIALDEVICE.println(F(" |"));
+			MY_SERIALDEVICE.println(
 			    F("+-------------------------------+-------------------------------++---------+---------+"));
 		} else if (i == 0x28) {
-			Serial.print(F("|          SlotConfig0A         |         SlotConfig0B          || "));
+			MY_SERIALDEVICE.print(F("|          SlotConfig0A         |         SlotConfig0B          || "));
 			for (int j=0; j<4; j++) {
 				if (rx_buffer[SHA204_BUFFER_POS_DATA+j] < 0x10) {
-					Serial.print('0'); // Because Serial.print does not 0-pad HEX
+					MY_SERIALDEVICE.print('0'); // Because MY_SERIALDEVICE.print does not 0-pad HEX
 				}
-				Serial.print(rx_buffer[SHA204_BUFFER_POS_DATA+j], HEX);
+				MY_SERIALDEVICE.print(rx_buffer[SHA204_BUFFER_POS_DATA+j], HEX);
 				if (j == 1) {
-					Serial.print(F(" | "));
+					MY_SERIALDEVICE.print(F(" | "));
 				} else if (j < 3) {
-					Serial.print(F("   "));
+					MY_SERIALDEVICE.print(F("   "));
 				}
 			}
-			Serial.println(F(" |"));
-			Serial.println(
+			MY_SERIALDEVICE.println(F(" |"));
+			MY_SERIALDEVICE.println(
 			    F("+-------------------------------+-------------------------------++---------+---------+"));
 		} else if (i == 0x2C) {
-			Serial.print(F("|          SlotConfig0C         |         SlotConfig0D          || "));
+			MY_SERIALDEVICE.print(F("|          SlotConfig0C         |         SlotConfig0D          || "));
 			for (int j=0; j<4; j++) {
 				if (rx_buffer[SHA204_BUFFER_POS_DATA+j] < 0x10) {
-					Serial.print('0'); // Because Serial.print does not 0-pad HEX
+					MY_SERIALDEVICE.print('0'); // Because MY_SERIALDEVICE.print does not 0-pad HEX
 				}
-				Serial.print(rx_buffer[SHA204_BUFFER_POS_DATA+j], HEX);
+				MY_SERIALDEVICE.print(rx_buffer[SHA204_BUFFER_POS_DATA+j], HEX);
 				if (j == 1) {
-					Serial.print(F(" | "));
+					MY_SERIALDEVICE.print(F(" | "));
 				} else if (j < 3) {
-					Serial.print(F("   "));
+					MY_SERIALDEVICE.print(F("   "));
 				}
 			}
-			Serial.println(F(" |"));
-			Serial.println(
+			MY_SERIALDEVICE.println(F(" |"));
+			MY_SERIALDEVICE.println(
 			    F("+-------------------------------+-------------------------------++---------+---------+"));
 		} else if (i == 0x30) {
-			Serial.print(F("|          SlotConfig0E         |         SlotConfig0F          || "));
+			MY_SERIALDEVICE.print(F("|          SlotConfig0E         |         SlotConfig0F          || "));
 			for (int j=0; j<4; j++) {
 				if (rx_buffer[SHA204_BUFFER_POS_DATA+j] < 0x10) {
-					Serial.print('0'); // Because Serial.print does not 0-pad HEX
+					MY_SERIALDEVICE.print('0'); // Because MY_SERIALDEVICE.print does not 0-pad HEX
 				}
-				Serial.print(rx_buffer[SHA204_BUFFER_POS_DATA+j], HEX);
+				MY_SERIALDEVICE.print(rx_buffer[SHA204_BUFFER_POS_DATA+j], HEX);
 				if (j == 1) {
-					Serial.print(F(" | "));
+					MY_SERIALDEVICE.print(F(" | "));
 				} else if (j < 3) {
-					Serial.print(F("   "));
+					MY_SERIALDEVICE.print(F("   "));
 				}
 			}
-			Serial.println(F(" |"));
-			Serial.println(
+			MY_SERIALDEVICE.println(F(" |"));
+			MY_SERIALDEVICE.println(
 			    F("+---------------+---------------+---------------+---------------++----+----+----+----+"));
 		} else if (i == 0x34) {
-			Serial.print(F("|   UseFlag00   | UpdateCount00 |   UseFlag01   | UpdateCount01 || "));
+			MY_SERIALDEVICE.print(F("|   UseFlag00   | UpdateCount00 |   UseFlag01   | UpdateCount01 || "));
 			for (int j=0; j<4; j++) {
 				if (rx_buffer[SHA204_BUFFER_POS_DATA+j] < 0x10) {
-					Serial.print('0'); // Because Serial.print does not 0-pad HEX
+					MY_SERIALDEVICE.print('0'); // Because MY_SERIALDEVICE.print does not 0-pad HEX
 				}
-				Serial.print(rx_buffer[SHA204_BUFFER_POS_DATA+j], HEX);
+				MY_SERIALDEVICE.print(rx_buffer[SHA204_BUFFER_POS_DATA+j], HEX);
 				if (j < 3) {
-					Serial.print(F(" | "));
+					MY_SERIALDEVICE.print(F(" | "));
 				} else {
-					Serial.println(F(" |"));
+					MY_SERIALDEVICE.println(F(" |"));
 				}
 			}
-			Serial.println(
+			MY_SERIALDEVICE.println(
 			    F("+---------------+---------------+---------------+---------------++----+----+----+----+"));
 		} else if (i == 0x38) {
-			Serial.print(F("|   UseFlag02   | UpdateCount02 |   UseFlag03   | UpdateCount03 || "));
+			MY_SERIALDEVICE.print(F("|   UseFlag02   | UpdateCount02 |   UseFlag03   | UpdateCount03 || "));
 			for (int j=0; j<4; j++) {
 				if (rx_buffer[SHA204_BUFFER_POS_DATA+j] < 0x10) {
-					Serial.print('0'); // Because Serial.print does not 0-pad HEX
+					MY_SERIALDEVICE.print('0'); // Because MY_SERIALDEVICE.print does not 0-pad HEX
 				}
-				Serial.print(rx_buffer[SHA204_BUFFER_POS_DATA+j], HEX);
+				MY_SERIALDEVICE.print(rx_buffer[SHA204_BUFFER_POS_DATA+j], HEX);
 				if (j < 3) {
-					Serial.print(F(" | "));
+					MY_SERIALDEVICE.print(F(" | "));
 				} else {
-					Serial.println(F(" |"));
+					MY_SERIALDEVICE.println(F(" |"));
 				}
 			}
-			Serial.println(
+			MY_SERIALDEVICE.println(
 			    F("+---------------+---------------+---------------+---------------++----+----+----+----+"));
 		} else if (i == 0x3C) {
-			Serial.print(F("|   UseFlag04   | UpdateCount04 |   UseFlag05   | UpdateCount05 || "));
+			MY_SERIALDEVICE.print(F("|   UseFlag04   | UpdateCount04 |   UseFlag05   | UpdateCount05 || "));
 			for (int j=0; j<4; j++) {
 				if (rx_buffer[SHA204_BUFFER_POS_DATA+j] < 0x10) {
-					Serial.print('0'); // Because Serial.print does not 0-pad HEX
+					MY_SERIALDEVICE.print('0'); // Because MY_SERIALDEVICE.print does not 0-pad HEX
 				}
-				Serial.print(rx_buffer[SHA204_BUFFER_POS_DATA+j], HEX);
+				MY_SERIALDEVICE.print(rx_buffer[SHA204_BUFFER_POS_DATA+j], HEX);
 				if (j < 3) {
-					Serial.print(F(" | "));
+					MY_SERIALDEVICE.print(F(" | "));
 				} else {
-					Serial.println(F(" |"));
+					MY_SERIALDEVICE.println(F(" |"));
 				}
 			}
-			Serial.println(
+			MY_SERIALDEVICE.println(
 			    F("+---------------+---------------+---------------+---------------++----+----+----+----+"));
 		} else if (i == 0x40) {
-			Serial.print(F("|   UseFlag06   | UpdateCount06 |   UseFlag07   | UpdateCount07 || "));
+			MY_SERIALDEVICE.print(F("|   UseFlag06   | UpdateCount06 |   UseFlag07   | UpdateCount07 || "));
 			for (int j=0; j<4; j++) {
 				if (rx_buffer[SHA204_BUFFER_POS_DATA+j] < 0x10) {
-					Serial.print('0'); // Because Serial.print does not 0-pad HEX
+					MY_SERIALDEVICE.print('0'); // Because MY_SERIALDEVICE.print does not 0-pad HEX
 				}
-				Serial.print(rx_buffer[SHA204_BUFFER_POS_DATA+j], HEX);
+				MY_SERIALDEVICE.print(rx_buffer[SHA204_BUFFER_POS_DATA+j], HEX);
 				if (j < 3) {
-					Serial.print(F(" | "));
+					MY_SERIALDEVICE.print(F(" | "));
 				} else {
-					Serial.println(F(" |"));
+					MY_SERIALDEVICE.println(F(" |"));
 				}
 			}
-			Serial.println(
+			MY_SERIALDEVICE.println(
 			    F("+---------------+---------------+---------------+---------------++----+----+----+----+"));
 		} else if (i == 0x44) {
-			Serial.print(F("|                        LastKeyUse[0:3]                        || "));
+			MY_SERIALDEVICE.print(F("|                        LastKeyUse[0:3]                        || "));
 			for (int j=0; j<4; j++) {
 				if (rx_buffer[SHA204_BUFFER_POS_DATA+j] < 0x10) {
-					Serial.print('0'); // Because Serial.print does not 0-pad HEX
+					MY_SERIALDEVICE.print('0'); // Because MY_SERIALDEVICE.print does not 0-pad HEX
 				}
-				Serial.print(rx_buffer[SHA204_BUFFER_POS_DATA+j], HEX);
+				MY_SERIALDEVICE.print(rx_buffer[SHA204_BUFFER_POS_DATA+j], HEX);
 				if (j < 3) {
-					Serial.print(F("   "));
+					MY_SERIALDEVICE.print(F("   "));
 				}
 			}
-			Serial.println(F(" |"));
-			Serial.println(
+			MY_SERIALDEVICE.println(F(" |"));
+			MY_SERIALDEVICE.println(
 			    F("+---------------------------------------------------------------++-------------------+"));
 		} else if (i == 0x48) {
-			Serial.print(F("|                        LastKeyUse[4:7]                        || "));
+			MY_SERIALDEVICE.print(F("|                        LastKeyUse[4:7]                        || "));
 			for (int j=0; j<4; j++) {
 				if (rx_buffer[SHA204_BUFFER_POS_DATA+j] < 0x10) {
-					Serial.print('0'); // Because Serial.print does not 0-pad HEX
+					MY_SERIALDEVICE.print('0'); // Because MY_SERIALDEVICE.print does not 0-pad HEX
 				}
-				Serial.print(rx_buffer[SHA204_BUFFER_POS_DATA+j], HEX);
+				MY_SERIALDEVICE.print(rx_buffer[SHA204_BUFFER_POS_DATA+j], HEX);
 				if (j < 3) {
-					Serial.print(F("   "));
+					MY_SERIALDEVICE.print(F("   "));
 				}
 			}
-			Serial.println(F(" |"));
-			Serial.println(
+			MY_SERIALDEVICE.println(F(" |"));
+			MY_SERIALDEVICE.println(
 			    F("+---------------------------------------------------------------++-------------------+"));
 		} else if (i == 0x4C) {
-			Serial.print(F("|                        LastKeyUse[8:B]                        || "));
+			MY_SERIALDEVICE.print(F("|                        LastKeyUse[8:B]                        || "));
 			for (int j=0; j<4; j++) {
 				if (rx_buffer[SHA204_BUFFER_POS_DATA+j] < 0x10) {
-					Serial.print('0'); // Because Serial.print does not 0-pad HEX
+					MY_SERIALDEVICE.print('0'); // Because MY_SERIALDEVICE.print does not 0-pad HEX
 				}
-				Serial.print(rx_buffer[SHA204_BUFFER_POS_DATA+j], HEX);
+				MY_SERIALDEVICE.print(rx_buffer[SHA204_BUFFER_POS_DATA+j], HEX);
 				if (j < 3) {
-					Serial.print(F("   "));
+					MY_SERIALDEVICE.print(F("   "));
 				}
 			}
-			Serial.println(F(" |"));
-			Serial.println(
+			MY_SERIALDEVICE.println(F(" |"));
+			MY_SERIALDEVICE.println(
 			    F("+---------------------------------------------------------------++-------------------+"));
 		} else if (i == 0x50) {
-			Serial.print(F("|                        LastKeyUse[C:F]                        || "));
+			MY_SERIALDEVICE.print(F("|                        LastKeyUse[C:F]                        || "));
 			for (int j=0; j<4; j++) {
 				if (rx_buffer[SHA204_BUFFER_POS_DATA+j] < 0x10) {
-					Serial.print('0'); // Because Serial.print does not 0-pad HEX
+					MY_SERIALDEVICE.print('0'); // Because MY_SERIALDEVICE.print does not 0-pad HEX
 				}
-				Serial.print(rx_buffer[SHA204_BUFFER_POS_DATA+j], HEX);
+				MY_SERIALDEVICE.print(rx_buffer[SHA204_BUFFER_POS_DATA+j], HEX);
 				if (j < 3) {
-					Serial.print(F("   "));
+					MY_SERIALDEVICE.print(F("   "));
 				}
 			}
-			Serial.println(F(" |"));
-			Serial.println(
+			MY_SERIALDEVICE.println(F(" |"));
+			MY_SERIALDEVICE.println(
 			    F("+---------------+---------------+---------------+---------------++----+----+----+----+"));
 		} else if (i == 0x54) {
-			Serial.print(F("|   UserExtra   |    Selector   |   LockValue   |  LockConfig   || "));
+			MY_SERIALDEVICE.print(F("|   UserExtra   |    Selector   |   LockValue   |  LockConfig   || "));
 			for (int j=0; j<4; j++) {
 				if (rx_buffer[SHA204_BUFFER_POS_DATA+j] < 0x10) {
-					Serial.print('0'); // Because Serial.print does not 0-pad HEX
+					MY_SERIALDEVICE.print('0'); // Because MY_SERIALDEVICE.print does not 0-pad HEX
 				}
-				Serial.print(rx_buffer[SHA204_BUFFER_POS_DATA+j], HEX);
+				MY_SERIALDEVICE.print(rx_buffer[SHA204_BUFFER_POS_DATA+j], HEX);
 				if (j < 3) {
-					Serial.print(F(" | "));
+					MY_SERIALDEVICE.print(F(" | "));
 				} else {
-					Serial.println(F(" |"));
+					MY_SERIALDEVICE.println(F(" |"));
 				}
 			}
-			Serial.println(
+			MY_SERIALDEVICE.println(
 			    F("+---------------+---------------+---------------+---------------++----+----+----+----+"));
 		}
 	}

--- a/examples/SensebenderGatewaySerial/SensebenderGatewaySerial.ino
+++ b/examples/SensebenderGatewaySerial/SensebenderGatewaySerial.ino
@@ -134,13 +134,13 @@ void preHwInit()
 	}
 	digitalWrite(LED_BLUE, LOW);
 	if (Serial) {
-		Serial.println("Sensebender GateWay test routine");
-		Serial.print("Mysensors core version : ");
-		Serial.println(MYSENSORS_LIBRARY_VERSION);
-		Serial.print("GateWay sketch version : ");
-		Serial.println(SKETCH_VERSION);
-		Serial.println("----------------------------------");
-		Serial.println();
+		MY_SERIALDEVICE.println("Sensebender GateWay test routine");
+		MY_SERIALDEVICE.print("Mysensors core version : ");
+		MY_SERIALDEVICE.println(MYSENSORS_LIBRARY_VERSION);
+		MY_SERIALDEVICE.print("GateWay sketch version : ");
+		MY_SERIALDEVICE.println(SKETCH_VERSION);
+		MY_SERIALDEVICE.println("----------------------------------");
+		MY_SERIALDEVICE.println();
 	}
 	if (testSha204()) {
 		digitalWrite(LED_GREEN, HIGH);
@@ -183,7 +183,7 @@ bool testSha204()
 	uint8_t rx_buffer[SHA204_RSP_SIZE_MAX];
 	uint8_t ret_code;
 	if (Serial) {
-		Serial.print("- > SHA204 ");
+		MY_SERIALDEVICE.print("- > SHA204 ");
 	}
 	atsha204_init(MY_SIGNING_ATSHA204_PIN);
 	ret_code = atsha204_wakeup(rx_buffer);
@@ -192,25 +192,25 @@ bool testSha204()
 		ret_code = atsha204_getSerialNumber(rx_buffer);
 		if (ret_code != SHA204_SUCCESS) {
 			if (Serial) {
-				Serial.println(F("Failed to obtain device serial number. Response: "));
+				MY_SERIALDEVICE.println(F("Failed to obtain device serial number. Response: "));
 			}
-			Serial.println(ret_code, HEX);
+			MY_SERIALDEVICE.println(ret_code, HEX);
 		} else {
 			if (Serial) {
-				Serial.print(F("Ok (serial : "));
+				MY_SERIALDEVICE.print(F("Ok (serial : "));
 				for (int i=0; i<9; i++) {
 					if (rx_buffer[i] < 0x10) {
-						Serial.print('0'); // Because Serial.print does not 0-pad HEX
+						MY_SERIALDEVICE.print('0'); // Because MY_SERIALDEVICE.print does not 0-pad HEX
 					}
-					Serial.print(rx_buffer[i], HEX);
+					MY_SERIALDEVICE.print(rx_buffer[i], HEX);
 				}
-				Serial.println(")");
+				MY_SERIALDEVICE.println(")");
 			}
 			return true;
 		}
 	} else {
 		if (Serial) {
-			Serial.println(F("Failed to wakeup SHA204"));
+			MY_SERIALDEVICE.println(F("Failed to wakeup SHA204"));
 		}
 	}
 	return false;
@@ -219,28 +219,28 @@ bool testSha204()
 bool testSDCard()
 {
 	if (Serial) {
-		Serial.print("- > SD CARD ");
+		MY_SERIALDEVICE.print("- > SD CARD ");
 	}
 	if (!card.init(SPI_HALF_SPEED, MY_SDCARD_CS)) {
 		if (Serial) {
-			Serial.println("SD CARD did not initialize!");
+			MY_SERIALDEVICE.println("SD CARD did not initialize!");
 		}
 	} else {
 		if (Serial) {
-			Serial.print("SD Card initialized correct! - ");
-			Serial.print("type detected : ");
+			MY_SERIALDEVICE.print("SD Card initialized correct! - ");
+			MY_SERIALDEVICE.print("type detected : ");
 			switch(card.type()) {
 			case SD_CARD_TYPE_SD1:
-				Serial.println("SD1");
+				MY_SERIALDEVICE.println("SD1");
 				break;
 			case SD_CARD_TYPE_SD2:
-				Serial.println("SD2");
+				MY_SERIALDEVICE.println("SD2");
 				break;
 			case SD_CARD_TYPE_SDHC:
-				Serial.println("SDHC");
+				MY_SERIALDEVICE.println("SDHC");
 				break;
 			default:
-				Serial.println("Unknown");
+				MY_SERIALDEVICE.println("Unknown");
 			}
 		}
 		return true;
@@ -270,12 +270,12 @@ bool testEEProm()
 bool testAnalog()
 {
 	int bat_detect = analogRead(MY_BAT_DETECT);
-	Serial.print("-> analog : ");
-	Serial.print(bat_detect);
+	MY_SERIALDEVICE.print("-> analog : ");
+	MY_SERIALDEVICE.print(bat_detect);
 	if (bat_detect < 400 || bat_detect > 650) {
-		Serial.println(" Failed");
+		MY_SERIALDEVICE.println(" Failed");
 		return false;
 	}
-	Serial.println(" Passed");
+	MY_SERIALDEVICE.println(" Passed");
 	return true;
 }

--- a/examples/SoilMoistSensor/SoilMoistSensor.ino
+++ b/examples/SoilMoistSensor/SoilMoistSensor.ino
@@ -120,22 +120,22 @@ void loop()
 {
 
 	measure(6,7,1);
-	Serial.print ("\t");
-	Serial.println (average());
+	MY_SERIALDEVICE.print ("\t");
+	MY_SERIALDEVICE.println (average());
 	long read1 = average();
 
 	measure(7,6,0);
-	Serial.print ("\t");
-	Serial.println (average());
+	MY_SERIALDEVICE.print ("\t");
+	MY_SERIALDEVICE.println (average());
 	long read2= average();
 
 	long sensor1 = (read1 + read2)/2;
 
-	Serial.print ("resistance bias =" );
-	Serial.println (read1-read2);
-	Serial.print ("sensor bias compensated value = ");
-	Serial.println (sensor1);
-	Serial.println ();
+	MY_SERIALDEVICE.print ("resistance bias =" );
+	MY_SERIALDEVICE.println (read1-read2);
+	MY_SERIALDEVICE.print ("sensor bias compensated value = ");
+	MY_SERIALDEVICE.println (sensor1);
+	MY_SERIALDEVICE.println ();
 
 	//send back the values
 	send(msg.set((long int)ceil(sensor1)));
@@ -171,8 +171,8 @@ void measure (int phase_b, int phase_a, int analog_input)
 
 		delay(1);
 		addReading(resistance);
-		Serial.print (resistance);
-		Serial.print ("\t");
+		MY_SERIALDEVICE.print (resistance);
+		MY_SERIALDEVICE.print ("\t");
 	}
 }
 

--- a/examples/UVSensor/UVSensor.ino
+++ b/examples/UVSensor/UVSensor.ino
@@ -79,8 +79,8 @@ void loop()
 		uv=1170;
 	}
 
-	//Serial.print("UV Analog reading: ");
-	//Serial.println(uv);
+	//MY_SERIALDEVICE.print("UV Analog reading: ");
+	//MY_SERIALDEVICE.println(uv);
 
 	int i;
 	for (i = 0; i < 12; i++) {
@@ -97,8 +97,8 @@ void loop()
 		uvIndex+=(1.0/vRange)*vCalc-1.0;
 	}
 
-	//Serial.print("UVI: ");
-	//Serial.println(uvIndex,2);
+	//MY_SERIALDEVICE.print("UVI: ");
+	//MY_SERIALDEVICE.println(uvIndex,2);
 
 	//Send value to gateway if changed, or at least every 5 minutes
 	if ((uvIndex != lastUV)||(currentTime-lastSend >= 5UL*60UL*1000UL)) {

--- a/examples/WaterMeterPulseSensor/WaterMeterPulseSensor.ino
+++ b/examples/WaterMeterPulseSensor/WaterMeterPulseSensor.ino
@@ -117,8 +117,8 @@ void loop()
 		if (!SLEEP_MODE && flow != oldflow) {
 			oldflow = flow;
 
-			Serial.print("l/min:");
-			Serial.println(flow);
+			MY_SERIALDEVICE.print("l/min:");
+			MY_SERIALDEVICE.println(flow);
 
 			// Check that we dont get unresonable large flow value.
 			// could hapen when long wraps or false interrupt triggered
@@ -136,8 +136,8 @@ void loop()
 		if ((pulseCount != oldPulseCount)||(!SLEEP_MODE)) {
 			oldPulseCount = pulseCount;
 
-			Serial.print("pulsecount:");
-			Serial.println(pulseCount);
+			MY_SERIALDEVICE.print("pulsecount:");
+			MY_SERIALDEVICE.println(pulseCount);
 
 			send(lastCounterMsg.set(pulseCount));                  // Send  pulsecount value to gw in VAR1
 
@@ -145,8 +145,8 @@ void loop()
 			if ((volume != oldvolume)||(!SLEEP_MODE)) {
 				oldvolume = volume;
 
-				Serial.print("volume:");
-				Serial.println(volume, 3);
+				MY_SERIALDEVICE.print("volume:");
+				MY_SERIALDEVICE.println(volume, 3);
 
 				send(volumeMsg.set(volume, 3));               // Send volume value to gw
 			}
@@ -163,8 +163,8 @@ void receive(const MyMessage &message)
 		unsigned long gwPulseCount=message.getULong();
 		pulseCount += gwPulseCount;
 		flow=oldflow=0;
-		Serial.print("Received last pulse count from gw:");
-		Serial.println(pulseCount);
+		MY_SERIALDEVICE.print("Received last pulse count from gw:");
+		MY_SERIALDEVICE.println(pulseCount);
 		pcReceived = true;
 	}
 }


### PR DESCRIPTION
MY_SERIALDEVICE is set (by the hardware abstraction layer)
to the appropriate device depending on which board is used.

Most boards use Serial, but SAMD doesn't, so to make the
examples work, MY_SERIALDEVICE should be used.

Command:
find examples -type f | xargs sed -i 's/Serial\.print/MY_SERIALDEVICE\.print/g'