### PR TITLE
Skip check personalization with simple passwd flag

### DIFF
--- a/core/MySigning.cpp
+++ b/core/MySigning.cpp
@@ -99,7 +99,8 @@ static void prepareSigningPresentation(MyMessage &msg, uint8_t destination);
 static bool signerInternalProcessPresentation(MyMessage &msg);
 static bool signerInternalProcessNonceRequest(MyMessage &msg);
 static bool signerInternalProcessNonceResponse(MyMessage &msg);
-#if defined(MY_ENCRYPTION_FEATURE) || defined(MY_SIGNING_FEATURE)
+#if (defined(MY_ENCRYPTION_FEATURE) || defined(MY_SIGNING_FEATURE)) &&\
+    !defined(MY_SIGNING_SIMPLE_PASSWD)
 static bool signerInternalValidatePersonalization(void);
 #endif
 
@@ -108,7 +109,8 @@ void signerInit(void)
 #if defined(MY_SIGNING_FEATURE)
 	stateValid = true;
 #endif
-#if defined (MY_ENCRYPTION_FEATURE) || defined (MY_SIGNING_FEATURE)
+#if (defined (MY_ENCRYPTION_FEATURE) || defined (MY_SIGNING_FEATURE)) &&\
+    !defined (MY_SIGNING_SIMPLE_PASSWD)
 	if (!signerInternalValidatePersonalization()) {
 		SIGN_DEBUG(PSTR("!SGN:PER:TAMPERED\n"));
 #if defined(MY_SIGNING_FEATURE)
@@ -563,7 +565,8 @@ static bool signerInternalProcessNonceResponse(MyMessage &msg)
 	return true; // No need to further process I_NONCE_RESPONSE
 }
 
-#if defined(MY_ENCRYPTION_FEATURE) || defined(MY_SIGNING_FEATURE)
+#if (defined(MY_ENCRYPTION_FEATURE) || defined(MY_SIGNING_FEATURE)) &&\
+    !defined(MY_SIGNING_SIMPLE_PASSWD)
 static bool signerInternalValidatePersonalization(void)
 {
 #ifdef __linux__

--- a/drivers/ATSHA204/sha256.cpp
+++ b/drivers/ATSHA204/sha256.cpp
@@ -165,6 +165,10 @@ uint8_t* Sha256Class::result(void)
 #define HMAC_IPAD 0x36
 #define HMAC_OPAD 0x5c
 
+HmacClass::HmacClass()
+{
+}
+
 void HmacClass::initHmac(const uint8_t* key, int keyLength)
 {
 	uint8_t i;

--- a/drivers/ATSHA204/sha256.h
+++ b/drivers/ATSHA204/sha256.h
@@ -37,6 +37,7 @@ private:
 class HmacClass : public Sha256Class
 {
 public:
+	HmacClass(); // Constructor
 	void initHmac(const uint8_t* secret, int secretLength);
 	uint8_t* resultHmac(void);
 private:


### PR DESCRIPTION
Personalization does not need validation if the simple password
security flag is set.

Fixes #914