### PR TITLE
NRF5 ESB redesign

### DIFF
--- a/MyConfig.h
+++ b/MyConfig.h
@@ -467,9 +467,10 @@
  * @def MY_NRF5_ESB_MODE
  * @brief nRF5 mode.
  *
- * - NRF5_250KBPS for 250kbs
+ * - NRF5_250KBPS for 250kbs (Deprecated. Only available for nRF51, nRF52822)
  * - NRF5_1MBPS for 1Mbps
- * - NRF5_2MBPS for 2Mbps.
+ * - NRF5_2MBPS for 2Mbps
+ * - NRF5_BLE_1MBPS for 1Mbps BLE modulation
  */
 #ifndef MY_NRF5_ESB_MODE
 #define MY_NRF5_ESB_MODE (NRF5_250KBPS)
@@ -503,16 +504,10 @@
 #endif
 
 /**
- * @def MY_NRF5_ESB_REVERSE_ACK_TX
- * @brief Switch to SI24R1 or faked nRF24L01+ compatible ACK mode. ACK bit is reversed on TX side.
+ * @def MY_NRF5_ESB_STRICT_ACK
+ * @brief Switch to original nRF24L01+ compatible ACK mode instead of answering all packages with ACK
  */
-//#define MY_NRF5_ESB_REVERSE_ACK_TX
-
-/**
- * @def MY_NRF5_ESB_REVERSE_ACK_RX
- * @brief Switch to SI24R1 or faked nRF24L01+ compatible ACK mode. ACK bit is reversed on RX side.
- */
-//#define MY_NRF5_ESB_REVERSE_ACK_RX
+//#define MY_NRF5_ESB_STRICT_ACK
 /** @}*/ // End of NRF5SettingGrpPub group
 
 /**
@@ -1871,8 +1866,7 @@
 // NRF5_ESB
 #define MY_NRF5_ESB_ENABLE_ENCRYPTION
 #define MY_DEBUG_VERBOSE_NRF5_ESB
-#define MY_NRF5_ESB_REVERSE_ACK_RX
-#define MY_NRF5_ESB_REVERSE_ACK_TX
+#define MY_NRF5_ESB_STRICT_ACK
 // RFM69
 #define MY_IS_RFM69HW
 #define MY_RFM69_NEW_DRIVER

--- a/drivers/NRF5/Radio.h
+++ b/drivers/NRF5/Radio.h
@@ -32,11 +32,6 @@
 #include <stdio.h>
 #include <string.h>
 
-// Timer to use
-#define NRF5_RADIO_TIMER NRF_TIMER2
-#define NRF5_RADIO_TIMER_IRQ_HANDLER TIMER2_IRQHandler
-#define NRF5_RADIO_TIMER_IRQN TIMER2_IRQn
-
 // debug
 #if defined(MY_DEBUG_VERBOSE_NRF5_ESB)
 #define NRF5_RADIO_DEBUG(x, ...) DEBUG_OUTPUT(x, ##__VA_ARGS__)	//!< DEBUG
@@ -66,8 +61,22 @@ typedef enum {
 typedef enum {
 	NRF5_1MBPS = RADIO_MODE_MODE_Nrf_1Mbit,
 	NRF5_2MBPS = RADIO_MODE_MODE_Nrf_2Mbit,
+#ifdef RADIO_MODE_MODE_Nrf_250Kbit
 	NRF5_250KBPS = RADIO_MODE_MODE_Nrf_250Kbit, // Deprecated!!!
+#endif
 	NRF5_BLE_1MBPS = RADIO_MODE_MODE_Ble_1Mbit,
+#ifdef RADIO_MODE_MODE_Ble_2Mbit
+	NRF5_BLE_2MBPS = RADIO_MODE_MODE_Ble_2Mbit,
+#endif
+#ifdef RADIO_MODE_MODE_Ble_LR125Kbit
+	NRF5_BLE_LR125KBPS = RADIO_MODE_MODE_Ble_LR125Kbit,
+#endif
+#ifdef RADIO_MODE_MODE_Ble_LR500Kbit
+	NRF5_BLE_LR500KBPS = RADIO_MODE_MODE_Ble_LR500Kbit,
+#endif
+#ifdef RADIO_MODE_MODE_Ieee802154_250Kbit
+	NRF5_BIEEE802154_250KBPS = RADIO_MODE_MODE_Ieee802154_250Kbit,
+#endif
 } nrf5_mode_e;
 
 int16_t NRF5_getTxPowerPercent(void);

--- a/drivers/NRF5/Radio_ESB.h
+++ b/drivers/NRF5/Radio_ESB.h
@@ -25,11 +25,6 @@
 #include "Radio.h"
 #include <Arduino.h>
 
-// Check SoftDevice presence
-#if defined(SOFTDEVICE_PRESENT) && !defined(FORCE_RADIO_ESB_WITH_SD)
-#error "NRF5 SoftDevice cannot be used with NRF5 Radio."
-#endif
-
 // Check maximum messae length
 #if MAX_MESSAGE_LENGTH > (32)
 #error "Unsupported message length. (MAX_MESSAGE_LENGTH)"
@@ -40,79 +35,102 @@
 #error "MY_NRF5_ESB_RX_BUFFER_SIZE must be greater than 3."
 #endif
 
-/** Wait for start of an ACK packet in us
- * Calculation: ramp up time + packet header (57 Bit): round to 9 Byte
- * If you don't receive ACK packages, you have to increase this value.
- * My measured (Aurduino Uno+NRF24L01P) minimal timeouts:
- *   250kbit 411us -> 182 us to ACK start
- *   1MBit   205us -> 147 us
- *   2MBit   173us -> 143 us
- */
-#define NRF5_ESB_ACK_WAIT                                                      \
-	((NRF5_ESB_RAMP_UP_TIME << 1) + (9 << NRF5_ESB_byte_time()))
+// Use timer 0 for predefined PPI for timer0
+#define NRF5_RADIO_TIMER NRF_TIMER0
+#define NRF5_RADIO_TIMER_IRQ_HANDLER TIMER0_IRQHandler
+#define NRF5_RADIO_TIMER_IRQN TIMER0_IRQn
 
+// To support other timers. Implement predefined PPI.
+// Option to force timer capture instead of PPI to save PPI channels
+//#define NRF5_ESB_DO_CAPTURE
+
+#ifdef RADIO_MODECNF0_RU_Fast
+// Enable fast ramp up
+#define NRF5_ESB_FAST_RU
+#endif
+
+/* Radio timing parameters */
+// Time (µS) before start TX(NRF51)
+#define NRF5_ESB_PRE_TX_TIME_SLOW_RAMPUP (8)
+// Time (µS) before start TX with fast rampup enabled (NRF52)
+#define NRF5_ESB_PRE_TX_TIME_FAST_RAMPUP (88)
+// Time (µS) before start RX after TX (NRF52)
+#define NRF5_ESB_PRE_RX_TIME_FAST_RAMPUP (85)
+// Time (µS) before start TX after RX aith ACK (NRF52)
+#define NRF5_ESB_POST_RX_TIME_FAST_RAMPUP (NRF5_ESB_PRE_TX_TIME_FAST_RAMPUP)
 // auto retry delay in us, don't set this value < 1500us@250kbit
 #define NRF5_ESB_ARD (1500)
-
+// Time to wait for ACK messages
+#define NRF5_ESB_ACK_WAIT (260)
 // auto retry count with noACK is false
 #define NRF5_ESB_ARC_ACK (15)
-
 // auto retry count with noACK is true
-#define NRF5_ESB_ARC_NOACK (15)
-
+#define NRF5_ESB_ARC_NOACK (3)
 // How often broadcast messages are send
-#define NRF5_ESB_BC_ARC (15)
+#define NRF5_ESB_BC_ARC (3)
+// RX timeout for NRF52 PAN#102 and for _disableRadio
+#define NRF5_ESB_RX_TIMEOUT (1500)
+// Timeout to stop TX (Bughandler, optional)
+//#define NRF5_ESB_TX_BUG_WORKAROUND
 
 // Node address index
 #define NRF5_ESB_NODE_ADDR (0)
 #define NRF5_ESB_NODE_ADDR_MSK (0xffffff00UL)
-
 // TX address index
 #define NRF5_ESB_TX_ADDR (4)
 #define NRF5_ESB_TX_ADDR_MSK (0xffffff00UL)
-
 // BC address index
 #define NRF5_ESB_BC_ADDR (7)
 #define NRF5_ESB_BC_ADDR_MSK (0xffffffffUL)
 
-// Shorts for RX mode
-#define NRF5_ESB_SHORTS_RX                                                     \
-	(RADIO_SHORTS_READY_START_Msk | RADIO_SHORTS_END_START_Msk |                 \
-	 RADIO_SHORTS_DISABLED_RXEN_Msk | RADIO_SHORTS_ADDRESS_BCSTART_Msk |         \
-	 RADIO_SHORTS_ADDRESS_RSSISTART_Msk | RADIO_SHORTS_DISABLED_RSSISTOP_Msk)
-
-// Shorts for TX mode
-#define NRF5_ESB_SHORTS_TX                                                     \
-	(RADIO_SHORTS_READY_START_Msk | RADIO_SHORTS_END_START_Msk |                 \
-	 RADIO_SHORTS_DISABLED_TXEN_Msk | RADIO_SHORTS_ADDRESS_BCSTART_Msk)
-
-// Shorts to switch from RX to TX
-#define NRF5_ESB_SHORTS_RX_TX                                                  \
-	(RADIO_SHORTS_END_DISABLE_Msk | RADIO_SHORTS_DISABLED_TXEN_Msk |             \
-	 RADIO_SHORTS_READY_START_Msk | RADIO_SHORTS_ADDRESS_BCSTART_Msk)
-
-// Shorts to switch from TX to RX
-#define NRF5_ESB_SHORTS_TX_RX                                                  \
-	(RADIO_SHORTS_END_DISABLE_Msk | RADIO_SHORTS_DISABLED_RXEN_Msk |             \
-	 RADIO_SHORTS_READY_START_Msk | RADIO_SHORTS_ADDRESS_BCSTART_Msk |           \
-	 RADIO_SHORTS_ADDRESS_RSSISTART_Msk | RADIO_SHORTS_DISABLED_RSSISTOP_Msk)
-
 // PPI Channels
-#define NRF5_ESB_PPI_TIMER_START 14
-#define NRF5_ESB_PPI_TIMER_RADIO_DISABLE 15
-#define NRF5_ESB_PPI_BITS                                                    \
-	((1 << NRF5_ESB_PPI_TIMER_START) |                                         \
-	 (1 << NRF5_ESB_PPI_TIMER_RADIO_DISABLE))
+#ifdef NRF51
+#define NRF5_ESB_PPI_CHANNEL_START (14)
+#define NRF5_ESB_PPI_BITMASK (0xFFF00000) | (1 << NRF5_ESB_PPI_CHANNEL_START) | (1 << (NRF5_ESB_PPI_CHANNEL_START+1))
+#else
+#define NRF5_ESB_PPI_CHANNEL_START (18)
+#define NRF5_ESB_PPI_BITMASK (0xFFF00000) | (1 << NRF5_ESB_PPI_CHANNEL_START) | (1 << (NRF5_ESB_PPI_CHANNEL_START+1))
+#endif
+#define NRF5_ESB_PPI_BITS (0)
 
-/** Bitcounter for Packet Control Field length
- * 6 Bits address length + 3 Bits S1 (NOACK + PID)
+/** @brief Use LEDs for debug output
+ *
+ * Debug LEDs
+ *	PIN_LED2 = Radio READY Event
+ *  PIN_LED3 = Radio ADDRESS Event
+ *  PIN_LED4 = Radio END Event
+ *  PIN_LED5 = Radio DISABLED Event
+ *  PIN_LED6 = In RX/TX_ACK (READY/ADDRESS..END/DISABLED)
+ *  PIN_LED7 = TX_ACK: TX
+ *  PIN_LED8 = TX_ACK: RX
+ *
  */
-#define NRF5_ESB_BITCOUNTER (9)
+//#define NRF5_ESB_ENABLE_DEBUG_LEDS
 
-/** ramp up time
- * Time to activate radio TX or RX mode
+// Define routine to enable/disable LED's
+#ifdef NRF5_ESB_ENABLE_DEBUG_LEDS
+#define NRF5_ESB_DEBUG_LED(x,y) digitalWrite(x,y)
+#else
+#define NRF5_ESB_DEBUG_LED(x,y)
+#endif
+
+/**
+ * @brief SM state
+ *
+ * This structure stores SM state definitions
  */
-#define NRF5_ESB_RAMP_UP_TIME (130)
+typedef struct {
+	size_t radioEvents;         //!< radio events to enable
+	size_t radioShorts;         //!< radio short cuts to enable
+	size_t rxAddresses;         //!< radio addresses to listen
+	size_t txAddress;           //!< radio address as TX destination
+	void(*radioReady)(void);	  //!< radio READY event function
+	void(*radioAddress)(void);	//!< radio ADDRESS event function
+	void(*radioEnd)(void);    	//!< radio END event function
+	void(*radioDisabled)(void);	//!< radio ADDRESS event function
+	size_t timerShorts;         //!< timer short cuts to enable
+	void(*ppiInit)(void);				//!< initialize PPI
+} esbState_t;
 
 
 static bool NRF5_ESB_initialize();
@@ -134,10 +152,10 @@ static bool NRF5_ESB_sendMessage(uint8_t recipient, const void *buf, uint8_t len
 static int16_t NRF5_ESB_getSendingRSSI();
 static int16_t NRF5_ESB_getReceivingRSSI();
 
-// Calculate time to transmit an byte in us as bit shift -> 2^X
-static inline uint8_t NRF5_ESB_byte_time();
-
-/** Structure of radio rackets
+/**
+ * @brief Structure of radio rackets
+ *
+ * This structure stores radio packets
  */
 typedef struct nrf5_radio_packet_s {
 	// structure written by radio unit
@@ -152,20 +170,23 @@ typedef struct nrf5_radio_packet_s {
 		};
 		uint8_t data[MAX_MESSAGE_LENGTH];
 		int8_t rssi;
-		/** Debug data structure */
-#ifdef MY_DEBUG_VERBOSE_NRF5_ESB
-		uint32_t rxmatch;
-#endif
 	}
 #ifndef DOXYGEN
 	__attribute__((packed));
 #endif
 } NRF5_ESB_Packet;
 
-#ifdef MY_DEBUG_VERBOSE_NRF5_ESB
-static uint32_t intcntr_bcmatch;
-static uint32_t intcntr_ready;
-static uint32_t intcntr_end;
-#endif
+/**
+ * @brief States of common radio buffer
+ *
+ * For what is the buffer used.
+ */
+typedef enum {
+	NRF5_ESB_BUFFER_STATE_DISABLED,
+	NRF5_ESB_BUFFER_STATE_TX,
+	NRF5_ESB_BUFFER_STATE_RX,
+	NRF5_ESB_BUFFER_STATE_TX_ACK,
+	NRF5_ESB_BUFFER_STATE_RX_ACK,
+} nrf_esb_buffer_states;
 
 #endif // __NRF5_H__

--- a/hal/architecture/NRF5/MyHwNRF5.cpp
+++ b/hal/architecture/NRF5/MyHwNRF5.cpp
@@ -66,6 +66,11 @@ void hwWriteConfig(int adr, uint8_t value)
 
 bool hwInit()
 {
+#ifdef SOFTDEVICE_PRESENT
+	// Disable the SoftDevice; requires NRF5 SDK available
+	sd_softdevice_disable();
+#endif
+
 	// Clock is manged by sleep modes. Radio depends on HFCLK.
 	// Force to start HFCLK
 	NRF_CLOCK->EVENTS_HFCLKSTARTED = 0;
@@ -285,13 +290,13 @@ void hwSleepEnd(uint32_t ms)
 
 	if (ms > 0) {
 		// Stop RTC
-#ifdef NRF51
-		MY_HW_RTC->POWER = 0;
-#endif
 		MY_HW_RTC->INTENCLR = RTC_INTENSET_COMPARE0_Msk;
 		MY_HW_RTC->EVTENCLR = RTC_EVTENSET_COMPARE0_Msk;
 		MY_HW_RTC->TASKS_STOP = 1;
 		NVIC_DisableIRQ(MY_HW_RTC_IRQN);
+#ifdef NRF51
+		MY_HW_RTC->POWER = 0;
+#endif
 	} else {
 		// Start Arduino RTC for millis()
 		NRF_RTC1->TASKS_START = 1;


### PR DESCRIPTION
    NRF5 ESB redesign
     - Fix nRF52 PAN#102
     - Fix nRF52 PAN#78
     - nRF52 Support for fast ramp up mode
     - Better to debug
     - Disable SoftDevice, if active and SDK available
