### PR TITLE
NVM: consideration of SoftDevice memory layout

### DIFF
--- a/drivers/NRF5/Flash.cpp
+++ b/drivers/NRF5/Flash.cpp
@@ -17,6 +17,7 @@
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 #include "drivers/NVM/Flash.h"
+#include <nrf.h>
 
 FlashClass Flash;
 
@@ -47,6 +48,19 @@ uint32_t FlashClass::specified_erase_cycles() const
 uint32_t *FlashClass::page_address(size_t page)
 {
 	return (uint32_t *)(page << page_size_bits());
+}
+
+uint32_t *FlashClass::top_app_page_address()
+{
+	// Bootcode at the top of the flash memory?
+	// https://infocenter.nordicsemi.com/index.jsp?topic=%2Fcom.nordic.infocenter.sdk5.v12.0.0%2Flib_bootloader.html
+	if (NRF_UICR->NRFFW[0]<0xFFFFFFFF) {
+		// Return pointer calculated by SoftDevice/bootloader
+		return (uint32_t *)NRF_UICR->NRFFW[0];
+	}
+
+	// Return flash length
+	return (uint32_t *)(Flash.page_count() << Flash.page_size_bits());
 }
 
 void FlashClass::erase(uint32_t *address, size_t size)

--- a/drivers/NVM/Flash.h
+++ b/drivers/NVM/Flash.h
@@ -30,12 +30,6 @@
 #include <Arduino.h>
 #include <stdio.h> // for size_t
 
-#ifdef __RFduino__
-#include <chip.h>
-#else
-#include <nrf.h>
-#endif
-
 /*
  * Define characteristics of Flash
  *
@@ -133,6 +127,10 @@ public:
 	 * @return address of given page
 	 */
 	uint32_t *page_address(size_t page);
+	/** Get top of available flash for application data
+	 * @return Last available address + 1
+	 */
+	uint32_t *top_app_page_address();
 	//----------------------------------------------------------------------------
 	/*
 	 * Accessing flash memory

--- a/drivers/NVM/VirtualPage.cpp
+++ b/drivers/NVM/VirtualPage.cpp
@@ -300,7 +300,7 @@ void VirtualPageClass::format()
 
 uint32_t *VirtualPageClass::get_page_address(uint16_t page)
 {
-	return (uint32_t *)((Flash.page_count() << Flash.page_size_bits()) -
+	return (uint32_t *)(Flash.top_app_page_address() -
 	                    ((page + VNM_VIRTUAL_PAGE_SKIP_FROM_TOP)
 	                     << VNM_VIRTUAL_PAGE_SIZE_BITS));
 }
@@ -336,7 +336,6 @@ void VirtualPageClass::build_page(uint32_t *address, uint32_t magic)
 uint32_t VirtualPageClass::get_page_erase_cycles(uint32_t *address)
 {
 	// Return number of cycles
-	return ((uint32_t)address[OFFSET_ERASE_COUNTER] &
-	        (uint32_t)MASK_ERASE_COUNTER) +
-	       1;
+	return ((((uint32_t)address[OFFSET_ERASE_COUNTER])+1) &
+	        (uint32_t)MASK_ERASE_COUNTER);
 }


### PR DESCRIPTION
This change takes care about the high flash memory used by the SoftDevice. The SoftDevice must be disabled via sd_softdevice_disable();