### PR TITLE
Clarify TSM:ID:FAIL message

### DIFF
--- a/core/MyTransport.h
+++ b/core/MyTransport.h
@@ -71,7 +71,7 @@
 * | | TSM | ID    |														| <b>Transition to stID state</b>
 * | | TSM | ID    | OK,ID=%%d									| Node ID is valid
 * | | TSM | ID    | REQ												| Request node ID from controller
-* |!| TSM | ID    | FAIL,ID=%%d								| ID verification failed, ID invalid
+* |!| TSM | ID    | FAIL,ID=%%d								| ID verification failed, ID invalid, no ID received from controller
 * | | TSM | UPL   |														| <b>Transition to stUplink state</b>
 * | | TSM | UPL   | OK												| Uplink OK, GW returned ping
 * | | TSF | UPL   | DGWC,O=%%d,N=%%d					| Uplink check revealed changed network topology, old distance (O), new distance (N)


### PR DESCRIPTION
As discussed in
https://forum.mysensors.org/topic/7931/noob-cant-get-sensor-talking-to-gateway/
and numerous other forum threads, many people don't understand
that id generation is done by the controller.

Many new users start out their first MySensors network with a
gateway, a single sensor node and no controller. Since MySensors
defaults to AUTO node id, the node gets stuck on TSM:ID:FAIL,
like this:
TSM:ID
TSM:ID:REQ
TSF:MSG:SEND,255-255-0-0,s=255,c=3,t=3,pt=0,l=0,sg=0,ft=0,st=OK:
TSM:ID
TSM:ID:REQ
TSF:MSG:SEND,255-255-0-0,s=255,c=3,t=3,pt=0,l=0,sg=0,ft=0,st=OK:
TSM:ID
TSM:ID:REQ
TSF:MSG:SEND,255-255-0-0,s=255,c=3,t=3,pt=0,l=0,sg=0,ft=0,st=OK:
TSM:ID
TSM:ID:REQ
TSF:MSG:SEND,255-255-0-0,s=255,c=3,t=3,pt=0,l=0,sg=0,ft=0,st=OK:
!TSM:ID:FAIL

This change adds a clarifying note about the controller in the
doxygen documentation.