### PR TITLE
Add MY_DEBUGDEVICE to redirect debug output

### DIFF
--- a/hal/architecture/AVR/MyHwAVR.cpp
+++ b/hal/architecture/AVR/MyHwAVR.cpp
@@ -313,17 +313,20 @@ uint16_t hwFreeMem()
 
 void hwDebugPrint(const char *fmt, ... )
 {
+#ifndef MY_DEBUGDEVICE
+#define MY_DEBUGDEVICE MY_SERIALDEVICE
+#endif
 #ifndef MY_DISABLED_SERIAL
 	char fmtBuffer[MY_SERIAL_OUTPUT_SIZE];
 #ifdef MY_GATEWAY_SERIAL
 	// prepend debug message to be handled correctly by controller (C_INTERNAL, I_LOG_MESSAGE)
 	snprintf_P(fmtBuffer, sizeof(fmtBuffer), PSTR("0;255;%" PRIu8 ";0;%" PRIu8 ";%" PRIu32 " "),
 	           C_INTERNAL, I_LOG_MESSAGE, hwMillis());
-	MY_SERIALDEVICE.print(fmtBuffer);
+	MY_DEBUGDEVICE.print(fmtBuffer);
 #else
 	// prepend timestamp
-	MY_SERIALDEVICE.print(hwMillis());
-	MY_SERIALDEVICE.print(F(" "));
+	MY_DEBUGDEVICE.print(hwMillis());
+	MY_DEBUGDEVICE.print(F(" "));
 #endif
 	va_list args;
 	va_start (args, fmt );
@@ -334,8 +337,8 @@ void hwDebugPrint(const char *fmt, ... )
 	fmtBuffer[sizeof(fmtBuffer) - 1] = '\0';
 #endif
 	va_end (args);
-	MY_SERIALDEVICE.print(fmtBuffer);
-	MY_SERIALDEVICE.flush();
+	MY_DEBUGDEVICE.print(fmtBuffer);
+	MY_DEBUGDEVICE.flush();
 #else
 	(void)fmt;
 #endif

--- a/hal/architecture/ESP8266/MyHwESP8266.cpp
+++ b/hal/architecture/ESP8266/MyHwESP8266.cpp
@@ -149,17 +149,20 @@ uint16_t hwFreeMem()
 
 void hwDebugPrint(const char *fmt, ... )
 {
+#ifndef MY_DEBUGDEVICE
+#define MY_DEBUGDEVICE MY_SERIALDEVICE
+#endif
 #ifndef MY_DISABLED_SERIAL
 	char fmtBuffer[MY_SERIAL_OUTPUT_SIZE];
 #ifdef MY_GATEWAY_SERIAL
 	// prepend debug message to be handled correctly by controller (C_INTERNAL, I_LOG_MESSAGE)
 	snprintf_P(fmtBuffer, sizeof(fmtBuffer), PSTR("0;255;%" PRIu8 ";0;%" PRIu8 ";%" PRIu32 " "),
 	           C_INTERNAL, I_LOG_MESSAGE, hwMillis());
-	MY_SERIALDEVICE.print(fmtBuffer);
+	MY_DEBUGDEVICE.print(fmtBuffer);
 #else
 	// prepend timestamp
-	MY_SERIALDEVICE.print(hwMillis());
-	MY_SERIALDEVICE.print(" ");
+	MY_DEBUGDEVICE.print(hwMillis());
+	MY_DEBUGDEVICE.print(" ");
 #endif
 	va_list args;
 	va_start (args, fmt );
@@ -170,8 +173,8 @@ void hwDebugPrint(const char *fmt, ... )
 	fmtBuffer[sizeof(fmtBuffer) - 1] = '\0';
 #endif
 	va_end (args);
-	MY_SERIALDEVICE.print(fmtBuffer);
-	MY_SERIALDEVICE.flush();
+	MY_DEBUGDEVICE.print(fmtBuffer);
+	MY_DEBUGDEVICE.flush();
 #else
 	(void)fmt;
 #endif

--- a/hal/architecture/NRF5/MyHwNRF5.cpp
+++ b/hal/architecture/NRF5/MyHwNRF5.cpp
@@ -507,17 +507,20 @@ uint16_t hwFreeMem()
 
 void hwDebugPrint(const char *fmt, ...)
 {
+#ifndef MY_DEBUGDEVICE
+#define MY_DEBUGDEVICE MY_SERIALDEVICE
+#endif
 #ifndef MY_DISABLED_SERIAL
 	char fmtBuffer[MY_SERIAL_OUTPUT_SIZE];
 #ifdef MY_GATEWAY_SERIAL
 	// prepend debug message to be handled correctly by controller (C_INTERNAL, I_LOG_MESSAGE)
 	snprintf(fmtBuffer, sizeof(fmtBuffer), PSTR("0;255;%" PRIu8 ";0;%" PRIu8 ";%" PRIu32 " "),
 	         C_INTERNAL, I_LOG_MESSAGE, hwMillis());
-	MY_SERIALDEVICE.print(fmtBuffer);
+	MY_DEBUGDEVICE.print(fmtBuffer);
 #else
 	// prepend timestamp
-	MY_SERIALDEVICE.print(hwMillis());
-	MY_SERIALDEVICE.print(F(" "));
+	MY_DEBUGDEVICE.print(hwMillis());
+	MY_DEBUGDEVICE.print(F(" "));
 #endif
 	va_list args;
 	va_start (args, fmt );
@@ -528,8 +531,8 @@ void hwDebugPrint(const char *fmt, ...)
 	fmtBuffer[sizeof(fmtBuffer) - 1] = '\0';
 #endif
 	va_end (args);
-	MY_SERIALDEVICE.print(fmtBuffer);
-	MY_SERIALDEVICE.flush();
+	MY_DEBUGDEVICE.print(fmtBuffer);
+	MY_DEBUGDEVICE.flush();
 #else
 	(void)fmt;
 #endif

--- a/hal/architecture/SAMD/MyHwSAMD.cpp
+++ b/hal/architecture/SAMD/MyHwSAMD.cpp
@@ -181,18 +181,21 @@ uint16_t hwFreeMem()
 
 void hwDebugPrint(const char *fmt, ... )
 {
+#ifndef MY_DEBUGDEVICE
+#define MY_DEBUGDEVICE MY_SERIALDEVICE
+#endif
 #ifndef MY_DISABLED_SERIAL
-	if (MY_SERIALDEVICE) {
+	if (MY_DEBUGDEVICE) {
 		char fmtBuffer[MY_SERIAL_OUTPUT_SIZE];
 #ifdef MY_GATEWAY_SERIAL
 		// prepend debug message to be handled correctly by controller (C_INTERNAL, I_LOG_MESSAGE)
 		snprintf(fmtBuffer, sizeof(fmtBuffer), PSTR("0;255;%" PRIu8 ";0;%" PRIu8 ";%" PRIu32 " "),
 		         C_INTERNAL, I_LOG_MESSAGE, hwMillis());
-		MY_SERIALDEVICE.print(fmtBuffer);
+		MY_DEBUGDEVICE.print(fmtBuffer);
 #else
 		// prepend timestamp
-		MY_SERIALDEVICE.print(hwMillis());
-		MY_SERIALDEVICE.print(" ");
+		MY_DEBUGDEVICE.print(hwMillis());
+		MY_DEBUGDEVICE.print(" ");
 #endif
 		va_list args;
 		va_start (args, fmt );
@@ -203,7 +206,7 @@ void hwDebugPrint(const char *fmt, ... )
 		fmtBuffer[sizeof(fmtBuffer) - 1] = '\0';
 #endif
 		va_end (args);
-		MY_SERIALDEVICE.print(fmtBuffer);
+		MY_DEBUGDEVICE.print(fmtBuffer);
 		//	MY_SERIALDEVICE.flush();
 	}
 #else

--- a/hal/architecture/STM32F1/MyHwSTM32F1.cpp
+++ b/hal/architecture/STM32F1/MyHwSTM32F1.cpp
@@ -170,17 +170,20 @@ uint16_t hwFreeMem()
 
 void hwDebugPrint(const char *fmt, ...)
 {
+#ifndef MY_DEBUGDEVICE
+#define MY_DEBUGDEVICE MY_SERIALDEVICE
+#endif
 #ifndef MY_DISABLED_SERIAL
 	char fmtBuffer[MY_SERIAL_OUTPUT_SIZE];
 #ifdef MY_GATEWAY_SERIAL
 	// prepend debug message to be handled correctly by controller (C_INTERNAL, I_LOG_MESSAGE)
 	snprintf_P(fmtBuffer, sizeof(fmtBuffer), PSTR("0;255;%" PRIu8 ";0;%" PRIu8 ";%" PRIu32 " "),
 	           C_INTERNAL, I_LOG_MESSAGE, hwMillis());
-	MY_SERIALDEVICE.print(fmtBuffer);
+	MY_DEBUGDEVICE.print(fmtBuffer);
 #else
 	// prepend timestamp
-	MY_SERIALDEVICE.print(hwMillis());
-	MY_SERIALDEVICE.print(" ");
+	MY_DEBUGDEVICE.print(hwMillis());
+	MY_DEBUGDEVICE.print(" ");
 #endif
 	va_list args;
 	va_start(args, fmt);
@@ -191,10 +194,10 @@ void hwDebugPrint(const char *fmt, ...)
 	fmtBuffer[sizeof(fmtBuffer) - 1] = '\0';
 #endif
 	va_end(args);
-	MY_SERIALDEVICE.print(fmtBuffer);
+	MY_DEBUGDEVICE.print(fmtBuffer);
 	// Disable flush since current STM32duino implementation performs a reset
 	// instead of an actual flush
-	//MY_SERIALDEVICE.flush();
+	//MY_DEBUGDEVICE.flush();
 #else
 	(void)fmt;
 #endif

--- a/hal/architecture/Teensy3/MyHwTeensy3.cpp
+++ b/hal/architecture/Teensy3/MyHwTeensy3.cpp
@@ -167,17 +167,20 @@ void hwRandomNumberInit(void)
 
 void hwDebugPrint(const char *fmt, ...)
 {
+#ifndef MY_DEBUGDEVICE
+#define MY_DEBUGDEVICE MY_SERIALDEVICE
+#endif
 #ifndef MY_DISABLED_SERIAL
 	char fmtBuffer[MY_SERIAL_OUTPUT_SIZE];
 #ifdef MY_GATEWAY_SERIAL
 	// prepend debug message to be handled correctly by controller (C_INTERNAL, I_LOG_MESSAGE)
 	snprintf_P(fmtBuffer, sizeof(fmtBuffer), PSTR("0;255;%" PRIu8 ";0;%" PRIu8 ";%" PRIu32 " "),
 	           C_INTERNAL, I_LOG_MESSAGE, hwMillis());
-	MY_SERIALDEVICE.print(fmtBuffer);
+	MY_DEBUGDEVICE.print(fmtBuffer);
 #else
 	// prepend timestamp
-	MY_SERIALDEVICE.print(hwMillis());
-	MY_SERIALDEVICE.print(F(" "));
+	MY_DEBUGDEVICE.print(hwMillis());
+	MY_DEBUGDEVICE.print(F(" "));
 #endif
 	va_list args;
 	va_start(args, fmt);
@@ -188,7 +191,7 @@ void hwDebugPrint(const char *fmt, ...)
 	fmtBuffer[sizeof(fmtBuffer) - 1] = '\0';
 #endif
 	va_end(args);
-	MY_SERIALDEVICE.print(fmtBuffer);
+	MY_DEBUGDEVICE.print(fmtBuffer);
 #else
 	(void)fmt;
 #endif


### PR DESCRIPTION
MY_DEBUGDEVICE, if defined, will replace MY_SERIALDEVICE
for the purpose of printing debug messages. This only
applies to debugging.

As discussed in the forum topic: MY_SERIALDEVICE overrides MY_DEBUG_HWSERIAL