### PR TITLE
Update reference to Code Contribution Guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,1 @@
-To get started, <a href="http://www.clahub.com/agreements/mysensors/MySensors">sign the Contributor License Agreement</a>.
+<a href="https://www.mysensors.org/download/contributing">MySensors Code Contribution Guidelines</a>


### PR DESCRIPTION
As mentioned by per1234 in
https://github.com/mysensors/MySensors/pull/1008
we should make it easier to find the full code contribution
guidelines.

Since we have multiple git repos, we don't want to duplicate the
guidelines in each repo. Instead, we link to the canonical source
on mysensors.org.