### PR TITLE
Linux/SerialPort: Log success message

### DIFF
--- a/drivers/Linux/SerialPort.cpp
+++ b/drivers/Linux/SerialPort.cpp
@@ -42,6 +42,7 @@ void SerialPort::begin(int bauds)
 		logError("Failed to open serial port.\n");
 		exit(1);
 	}
+	logDebug("Serial port %s (%d baud) created\n", serialPort.c_str(), bauds);
 }
 
 bool SerialPort::open(int bauds)


### PR DESCRIPTION
This log message makes the Serial gateway print the serial port path,
similar to how the Ethernet gateway prints IP and port.

Example log output:
mysgw: Serial port /dev/MyCoolTTY (115200 baud) created