### PR TITLE
Add URL option for mqtt broker in example sketch

### DIFF
--- a/examples/GatewayESP8266MQTTClient/GatewayESP8266MQTTClient.ino
+++ b/examples/GatewayESP8266MQTTClient/GatewayESP8266MQTTClient.ino
@@ -100,6 +100,9 @@
 // MQTT broker ip address.
 #define MY_CONTROLLER_IP_ADDRESS 192, 168, 178, 68
 
+//MQTT broker if using URL instead of ip address.
+// #define MY_CONTROLLER_URL_ADDRESS "test.mosquitto.org"
+
 // The MQTT broker port to to open
 #define MY_PORT 1883
 


### PR DESCRIPTION
Added the define in the example sketch for MQTT GW, to make the option more accessible. 
(first commit)