### PR TITLE
Fix cppcheck issues

### DIFF
--- a/examples/SecretKnockSensor/SecretKnockSensor.ino
+++ b/examples/SecretKnockSensor/SecretKnockSensor.ino
@@ -302,8 +302,7 @@ bool validateKnock()
 	    less of a pain to use if you're tempo is a little slow or fast.
 	*/
 	int totaltimeDifferences = 0;
-	int timeDiff = 0;
-	for (i=0; i < maximumKnocks; i++) {   // Normalize the times
+	for (int timeDiff = 0, i=0; i < maximumKnocks; i++) {   // Normalize the times
 		knockReadings[i]= map(knockReadings[i], 0, maxKnockInterval, 0, 100);
 		timeDiff = abs(knockReadings[i] - secretCode[i]);
 		if (timeDiff >

--- a/examples/SensebenderGatewaySerial/SensebenderGatewaySerial.ino
+++ b/examples/SensebenderGatewaySerial/SensebenderGatewaySerial.ino
@@ -124,8 +124,8 @@ void preHwInit()
 	for (int i=0; i< num_of_leds; i++) {
 		pinMode(leds[i], OUTPUT);
 	}
-	uint8_t led_state = 0;
 	if (digitalRead(MY_SWC1)) {
+		uint8_t led_state = 0;
 		while (!Serial) {
 			digitalWrite(LED_BLUE, led_state);
 			led_state ^= 0x01;


### PR DESCRIPTION
Fixes the following cppcheck issues:
examples/SecretKnockSensor/SecretKnockSensor.ino
305	variableScope	398	style
The scope of the variable 'timeDiff' can be reduced.

examples/SensebenderGatewaySerial/SensebenderGatewaySerial.ino
127	variableScope	398	style
The scope of the variable 'led_state' can be reduced.