### PR TITLE
Linux: Serial minor update

### DIFF
--- a/MyConfig.h
+++ b/MyConfig.h
@@ -1730,29 +1730,39 @@
  * @brief These options control Linux specific configurations.
  * @{
  */
+
 /**
  * @def MY_LINUX_SERIAL_PORT
  * @brief Serial device port
  */
-#ifndef MY_LINUX_SERIAL_PORT
-#define MY_LINUX_SERIAL_PORT "/dev/ttyACM0"
+//#define MY_LINUX_SERIAL_PORT "/dev/ttyUSB0"
+
+/**
+ * @def MY_LINUX_SERIAL_PTY
+ * @brief deprecated option
+ */
+#ifdef MY_LINUX_SERIAL_PTY
+#warning MY_LINUX_SERIAL_PTY is deprecated, please use MY_LINUX_SERIAL_PORT
+#define MY_LINUX_SERIAL_PORT MY_LINUX_SERIAL_PTY
 #endif
 
 /**
  * @def MY_LINUX_IS_SERIAL_PTY
+ * @brief deprecated option
+ */
+#ifdef MY_LINUX_IS_SERIAL_PTY
+#warning MY_LINUX_IS_SERIAL_PTY is deprecated, please use MY_LINUX_SERIAL_IS_PTY
+#define MY_LINUX_SERIAL_IS_PTY
+#endif
+
+/**
+ * @def MY_LINUX_SERIAL_IS_PTY
  * @brief Set serial as a pseudo terminal.
  *
  * Enable this if you need to connect to a controller running on the same device.
+ * You also need to define MY_LINUX_SERIAL_PORT with the symlink name for the PTY device.
  */
-//#define MY_LINUX_IS_SERIAL_PTY
-
-/**
- * @def MY_LINUX_SERIAL_PTY
- * @brief Symlink name for the PTY device.
- */
-#ifndef MY_LINUX_SERIAL_PTY
-#define MY_LINUX_SERIAL_PTY "/dev/ttyMySensorsGateway"
-#endif
+//#define MY_LINUX_SERIAL_IS_PTY
 
 /**
  * @def MY_LINUX_SERIAL_GROUPNAME
@@ -1908,7 +1918,10 @@
 #define MY_DISABLED_SERIAL
 #define MY_SPLASH_SCREEN_DISABLED
 // linux
+#define MY_LINUX_SERIAL_PORT
+#define MY_LINUX_SERIAL_IS_PTY
 #define MY_LINUX_SERIAL_GROUPNAME
+#define MY_LINUX_SERIAL_PTY
 #define MY_LINUX_IS_SERIAL_PTY
 // inclusion mode
 #define MY_INCLUSION_MODE_FEATURE

--- a/configure
+++ b/configure
@@ -47,11 +47,12 @@ MySensors options:
                                 Controller or MQTT broker ip.
     --my-port=<PORT>            The port to keep open on gateway mode.
                                 If gateway is set to mqtt, it sets the broker port.
-    --my-serial-port=<PORT>     Serial port. [/dev/ttyACM0]
+    --my-serial-port=<PORT>     Serial port.
     --my-serial-baudrate=<BAUD> Serial baud rate. [115200]
     --my-serial-is-pty          Set the serial port to be a pseudo terminal. Use this if you want
                                 to connect to a controller running on the same device.
-    --my-serial-pty=<NAME>      Symlink name for the PTY device. [/dev/ttyMySensorsGateway]
+                                You also need to set the symlink name for the PTY device with
+                                the --my-serial-port option.
     --my-serial-groupname=<GROUP>
                                 Grant access to the specified system group for the serial device.
     --my-mqtt-client-id=<ID>    MQTT client id.
@@ -338,10 +339,6 @@ for opt do
     --my-transport=*)
         transport_type=${optarg}
         ;;
-    --my-radio=*)
-        echo "Warning: --my-radio is deprecated, please use --my-transport"
-        transport_type=${optarg}
-        ;;
     --my-serial-port=*)
         CPPFLAGS="-DMY_LINUX_SERIAL_PORT=\\\"${optarg}\\\" $CPPFLAGS"
         ;;
@@ -349,10 +346,11 @@ for opt do
         CPPFLAGS="-DMY_BAUD_RATE=${optarg} $CPPFLAGS"
         ;;
     --my-serial-is-pty*)
-        CPPFLAGS="-DMY_LINUX_IS_SERIAL_PTY $CPPFLAGS"
+        CPPFLAGS="-DMY_LINUX_SERIAL_IS_PTY $CPPFLAGS"
         ;;
     --my-serial-pty=*)
-        CPPFLAGS="-DMY_LINUX_SERIAL_PTY=\\\"${optarg}\\\" $CPPFLAGS"
+        echo "Warning: --my-serial-pty is deprecated, please use --my-serial-port"
+        CPPFLAGS="-DMY_LINUX_SERIAL_PORT=\\\"${optarg}\\\" $CPPFLAGS"
         ;;
     --my-serial-groupname=*)
         CPPFLAGS="-DMY_LINUX_SERIAL_GROUPNAME=\\\"${optarg}\\\" $CPPFLAGS"

--- a/drivers/Linux/StdInOutStream.cpp
+++ b/drivers/Linux/StdInOutStream.cpp
@@ -18,39 +18,39 @@
  */
 
 #include <stdio.h>
-#include "SerialSimulator.h"
+#include "StdInOutStream.h"
 
-void SerialSimulator::begin(int baud)
+void StdInOutStream::begin(int baud)
 {
 	(void)baud;
 }
 
-int SerialSimulator::available()
+int StdInOutStream::available()
 {
 	return 1;
 }
 
-int SerialSimulator::read()
+int StdInOutStream::read()
 {
 	return getchar();
 }
 
-size_t SerialSimulator::write(uint8_t b)
+size_t StdInOutStream::write(uint8_t b)
 {
 	return (size_t)::printf("%c", b);
 }
 
-int SerialSimulator::peek()
+int StdInOutStream::peek()
 {
 	return -1;
 }
 
-void SerialSimulator::flush()
+void StdInOutStream::flush()
 {
 	fflush(stdout);
 }
 
-void SerialSimulator::end()
+void StdInOutStream::end()
 {
 	flush();
 }

--- a/drivers/Linux/StdInOutStream.h
+++ b/drivers/Linux/StdInOutStream.h
@@ -17,8 +17,8 @@
  * version 2 as published by the Free Software Foundation.
  */
 
-#ifndef SerialSimulator_h
-#define SerialSimulator_h
+#ifndef StdInOutStream_h
+#define StdInOutStream_h
 
 #include <stdlib.h>
 #include <stdio.h>
@@ -26,9 +26,9 @@
 #include "Stream.h"
 
 /**
- * @brief A class equivalent to Serial in Arduino but outputs to stdout
+ * @brief A class that prints to stdout and reads from stdin
  */
-class SerialSimulator : public Stream
+class StdInOutStream : public Stream
 {
 
 public:

--- a/examples_linux/mysgw.cpp
+++ b/examples_linux/mysgw.cpp
@@ -31,11 +31,10 @@
 
 // Serial config
 // Enable this if you are using an Arduino connected to the USB
-//#define MY_LINUX_SERIAL_PORT "/dev/ttyACM0"
+//#define MY_LINUX_SERIAL_PORT "/dev/ttyUSB0"
 // Enable this if you need to connect to a controller running on the same device
-//#define MY_LINUX_IS_SERIAL_PTY
-// Choose a symlink name for the PTY device
-//#define MY_LINUX_SERIAL_PTY "/dev/ttyMySensorsGateway"
+// You also need to define MY_LINUX_SERIAL_PORT above with the symlink name for the PTY device
+//#define MY_LINUX_SERIAL_IS_PTY
 // Grant access to the specified system group for the serial device
 //#define MY_LINUX_SERIAL_GROUPNAME "tty"
 

--- a/hal/architecture/Linux/MyHwLinuxGeneric.cpp
+++ b/hal/architecture/Linux/MyHwLinuxGeneric.cpp
@@ -165,8 +165,37 @@ void hwPinMode(uint8_t pin, uint8_t mode)
 
 void hwDebugPrint(const char *fmt, ...)
 {
+#ifndef MY_DISABLED_SERIAL
+#ifdef MY_DEBUGDEVICE
+	char fmtBuffer[MY_SERIAL_OUTPUT_SIZE];
+#ifdef MY_GATEWAY_SERIAL
+	// prepend debug message to be handled correctly by controller (C_INTERNAL, I_LOG_MESSAGE)
+	snprintf_P(fmtBuffer, sizeof(fmtBuffer), PSTR("0;255;%" PRIu8 ";0;%" PRIu8 ";%" PRIu32 " "),
+	           C_INTERNAL, I_LOG_MESSAGE, hwMillis());
+	MY_DEBUGDEVICE.print(fmtBuffer);
+#else
+	// prepend timestamp
+	MY_DEBUGDEVICE.print(hwMillis());
+	MY_DEBUGDEVICE.print(" ");
+#endif
+	va_list args;
+	va_start (args, fmt );
+	vsnprintf_P(fmtBuffer, sizeof(fmtBuffer), fmt, args);
+#ifdef MY_GATEWAY_SERIAL
+	// Truncate message if this is gateway node
+	fmtBuffer[sizeof(fmtBuffer) - 2] = '\n';
+	fmtBuffer[sizeof(fmtBuffer) - 1] = '\0';
+#endif
+	va_end (args);
+	MY_DEBUGDEVICE.print(fmtBuffer);
+	MY_DEBUGDEVICE.flush();
+#else
 	va_list args;
 	va_start(args, fmt);
 	vlogDebug(fmt, args);
 	va_end(args);
+#endif
+#else
+	(void)fmt;
+#endif
 }

--- a/hal/architecture/Linux/MyHwLinuxGeneric.h
+++ b/hal/architecture/Linux/MyHwLinuxGeneric.h
@@ -23,16 +23,16 @@
 #include <cstdlib>
 #include <pthread.h>
 #include "SerialPort.h"
-#include "SerialSimulator.h"
+#include "StdInOutStream.h"
 
-#ifdef MY_GATEWAY_SERIAL
-#ifdef MY_LINUX_IS_SERIAL_PTY
-SerialPort Serial = SerialPort(MY_LINUX_SERIAL_PTY, true);
+#ifdef MY_LINUX_SERIAL_PORT
+#ifdef MY_LINUX_SERIAL_IS_PTY
+SerialPort Serial = SerialPort(MY_LINUX_SERIAL_PORT, true);
 #else
-SerialPort Serial = SerialPort(MY_LINUX_SERIAL_PORT);
+SerialPort Serial = SerialPort(MY_LINUX_SERIAL_PORT, false);
 #endif
 #else
-SerialSimulator Serial = SerialSimulator();
+StdInOutStream Serial = StdInOutStream();
 #endif
 
 #ifndef MY_SERIALDEVICE


### PR DESCRIPTION
- The symlink name for the PTY device is set using --my-serial-port
  making --my-serial-pty deprecated
- Replace MY_LINUX_IS_SERIAL_PTY with MY_LINUX_SERIAL_IS_PTY
- MY_DEBUGDEVICE can be used to print debug messages from MySensors
  (as it is currently in the other architectures)
- Rename SerialSimulator class to StdInOutStream
- Remove old deprecated option --my-radio