### PR TITLE
Fix default IRQ pins on ESP8266 that prevent MCU from boot

### DIFF
--- a/drivers/RFM69/new/RFM69_new.h
+++ b/drivers/RFM69/new/RFM69_new.h
@@ -78,7 +78,7 @@
 #define DEFAULT_RFM69_IRQ_PIN			(2)												//!< DEFAULT_RFM69_IRQ_PIN
 #endif
 #elif defined(ARDUINO_ARCH_ESP8266)
-#define DEFAULT_RFM69_IRQ_PIN			(2)												//!< DEFAULT_RFM69_IRQ_PIN
+#define DEFAULT_RFM69_IRQ_PIN			(5)												//!< DEFAULT_RFM69_IRQ_PIN
 #elif defined(ARDUINO_ARCH_ESP32)
 #warning not implemented yet
 #elif defined(ARDUINO_ARCH_SAMD)

--- a/drivers/RFM69/old/RFM69_old.h
+++ b/drivers/RFM69/old/RFM69_old.h
@@ -43,7 +43,7 @@
 #endif
 #define DEFAULT_RFM69_IRQ_NUM			digitalPinToInterrupt(MY_RFM69_IRQ_PIN)		//!< DEFAULT_RFM69_IRQ_NUM
 #elif defined(ARDUINO_ARCH_ESP8266)
-#define DEFAULT_RFM69_IRQ_PIN			(2)													//!< DEFAULT_RFM69_IRQ_PIN
+#define DEFAULT_RFM69_IRQ_PIN			(5)													//!< DEFAULT_RFM69_IRQ_PIN
 #define DEFAULT_RFM69_IRQ_NUM			digitalPinToInterrupt(MY_RFM69_IRQ_PIN)		//!< DEFAULT_RFM69_IRQ_NUM
 #elif defined(ARDUINO_ARCH_ESP32)
 #warning not implemented yet

--- a/drivers/RFM69/old/RFM69_old.h
+++ b/drivers/RFM69/old/RFM69_old.h
@@ -41,15 +41,15 @@
 #else
 #define DEFAULT_RFM69_IRQ_PIN			(2)													//!< DEFAULT_RFM69_IRQ_PIN
 #endif
-#define DEFAULT_RFM69_IRQ_NUM			digitalPinToInterrupt(DEFAULT_RFM69_IRQ_PIN)		//!< DEFAULT_RFM69_IRQ_NUM
+#define DEFAULT_RFM69_IRQ_NUM			digitalPinToInterrupt(MY_RFM69_IRQ_PIN)		//!< DEFAULT_RFM69_IRQ_NUM
 #elif defined(ARDUINO_ARCH_ESP8266)
 #define DEFAULT_RFM69_IRQ_PIN			(2)													//!< DEFAULT_RFM69_IRQ_PIN
-#define DEFAULT_RFM69_IRQ_NUM			digitalPinToInterrupt(DEFAULT_RFM69_IRQ_PIN)		//!< DEFAULT_RFM69_IRQ_NUM
+#define DEFAULT_RFM69_IRQ_NUM			digitalPinToInterrupt(MY_RFM69_IRQ_PIN)		//!< DEFAULT_RFM69_IRQ_NUM
 #elif defined(ARDUINO_ARCH_ESP32)
 #warning not implemented yet
 #elif defined(ARDUINO_ARCH_SAMD)
 #define DEFAULT_RFM69_IRQ_PIN			(2)													//!< DEFAULT_RFM69_IRQ_PIN
-#define DEFAULT_RFM69_IRQ_NUM			digitalPinToInterrupt(DEFAULT_RFM69_IRQ_PIN)		//!< DEFAULT_RFM69_IRQ_NUM
+#define DEFAULT_RFM69_IRQ_NUM			digitalPinToInterrupt(MY_RFM69_IRQ_PIN)		//!< DEFAULT_RFM69_IRQ_NUM
 #elif defined(LINUX_ARCH_RASPBERRYPI)
 #define DEFAULT_RFM69_IRQ_PIN			(22)												//!< DEFAULT_RFM69_IRQ_PIN
 #define DEFAULT_RFM69_IRQ_NUM			DEFAULT_RFM69_IRQ_PIN								//!< DEFAULT_RFM69_IRQ_NUM
@@ -58,7 +58,7 @@
 #define DEFAULT_RFM69_IRQ_NUM			DEFAULT_RFM69_IRQ_PIN								//!< DEFAULT_RFM69_IRQ_NUM
 #elif defined(TEENSYDUINO)
 #define DEFAULT_RFM69_IRQ_PIN			(8)													//!< DEFAULT_RFM69_IRQ_PIN
-#define DEFAULT_RFM69_IRQ_NUM			digitalPinToInterrupt(DEFAULT_RFM69_IRQ_PIN)		//!< DEFAULT_RFM69_IRQ_NUM
+#define DEFAULT_RFM69_IRQ_NUM			digitalPinToInterrupt(MY_RFM69_IRQ_PIN)		//!< DEFAULT_RFM69_IRQ_NUM
 #else
 #define DEFAULT_RFM69_IRQ_PIN			(2)													//!< DEFAULT_RFM69_IRQ_PIN
 #define DEFAULT_RFM69_IRQ_NUM			(2)													//!< DEFAULT_RFM69_IRQ_NUM

--- a/drivers/RFM95/RFM95.h
+++ b/drivers/RFM95/RFM95.h
@@ -89,7 +89,7 @@
 #define DEFAULT_RFM95_IRQ_PIN			(2)				//!< DEFAULT_RFM95_IRQ_PIN
 #endif
 #elif defined(ARDUINO_ARCH_ESP8266)
-#define DEFAULT_RFM95_IRQ_PIN			(2)				//!< DEFAULT_RFM95_IRQ_PIN
+#define DEFAULT_RFM95_IRQ_PIN			(5)				//!< DEFAULT_RFM95_IRQ_PIN
 #elif defined(ARDUINO_ARCH_ESP32)
 #warning not implemented yet
 #elif defined(ARDUINO_ARCH_SAMD)


### PR DESCRIPTION
This PR fixes #1075 by changing the default IRQ pin for RFM69 and RFM95 on ESP8266 to D1, which is in accordance to the [documentation](https://www.mysensors.org/build/connect_radio#rfm6995-&-esp8266).

I also changed the default for IRQ_NUM in the old RFM69 driver to get the interrupt number from the configured, not the default pin. This is intentionally done in a separate commit.

See also [forum thread](https://forum.mysensors.org/topic/9083/cannot-get-rfm69hw-connection-between-esp8266gw-and-pro-mini-sensor/26)