### PR TITLE
Fix RFMxx deadlock and minor optimization

### DIFF
--- a/drivers/RFM95/RFM95.cpp
+++ b/drivers/RFM95/RFM95.cpp
@@ -551,7 +551,7 @@ LOCAL bool RFM95_sendWithRetry(const uint8_t recipient, const void *buffer,
 			return true;
 		}
 		const uint32_t enterMS = hwMillis();
-		while (hwMillis() - enterMS < retryWaitTime) {
+		while (hwMillis() - enterMS < retryWaitTime && !RFM95.dataReceived) {
 			RFM95_handler();
 			if (RFM95.ackReceived) {
 				const uint8_t sender = RFM95.currentPacket.header.sender;


### PR DESCRIPTION
- Fixes a potential RFM69/95 deadlock if data instead of expected ACK is received
- RFM69: remove clearFIFO() redundancy