### PR TITLE
Fix for ESP8266 Gateway with static IP

### DIFF
--- a/core/MyGatewayTransportEthernet.cpp
+++ b/core/MyGatewayTransportEthernet.cpp
@@ -123,9 +123,6 @@ bool gatewayTransportInit(void)
 #if defined(MY_ESP8266_HOSTNAME)
 	WiFi.hostname(MY_ESP8266_HOSTNAME);
 #endif /* End of MY_ESP8266_HOSTNAME */
-#if defined(MY_IP_ADDRESS)
-	WiFi.config(_ethernetGatewayIP, _gatewayIp, _subnetIp);
-#endif /* End of MY_IP_ADDRESS */
 #ifndef MY_ESP8266_BSSID
 #define MY_ESP8266_BSSID NULL
 #endif
@@ -136,6 +133,9 @@ bool gatewayTransportInit(void)
 	}
 	GATEWAY_DEBUG(PSTR("GWT:TIN:IP=%s\n"), WiFi.localIP().toString().c_str());
 #endif /* End of MY_ESP8266_SSID */
+#if defined(MY_IP_ADDRESS)
+	WiFi.config(_ethernetGatewayIP, _gatewayIp, _subnetIp);
+#endif /* End of MY_IP_ADDRESS */
 #elif defined(MY_GATEWAY_LINUX) /* Elif part of MY_GATEWAY_ESP8266 */
 	// Nothing to do here
 #else /* Else part of MY_GATEWAY_ESP8266 */

--- a/core/MyGatewayTransportMQTTClient.cpp
+++ b/core/MyGatewayTransportMQTTClient.cpp
@@ -112,6 +112,7 @@ bool gatewayTransportConnect(void)
 	GATEWAY_DEBUG(PSTR("GWT:TPC:IP=%s\n"),WiFi.localIP().toString().c_str());
 #elif defined(MY_GATEWAY_LINUX) /* Elif part of MY_GATEWAY_ESP8266 */
 #if defined(MY_IP_ADDRESS)
+	WiFi.config(_MQTT_clientIp, _gatewayIp, _subnetIp);
 	_MQTT_ethClient.bind(_MQTT_clientIp);
 #endif /* End of MY_IP_ADDRESS */
 #else /* Else part of MY_GATEWAY_ESP8266 */
@@ -151,9 +152,6 @@ bool gatewayTransportInit(void)
 #if defined(MY_ESP8266_HOSTNAME)
 	WiFi.hostname(MY_ESP8266_HOSTNAME);
 #endif /* End of MY_ESP8266_HOSTNAME */
-#if defined(MY_IP_ADDRESS)
-	WiFi.config(_MQTT_clientIp, _gatewayIp, _subnetIp);
-#endif /* End of MY_IP_ADDRESS */
 #ifndef MY_ESP8266_BSSID
 #define MY_ESP8266_BSSID NULL
 #endif


### PR DESCRIPTION
According to this: https://github.com/esp8266/Arduino/issues/128

Wifi.config() needs to be called after Wifi.begin().
Otherwise the static IP issn't used by the ESP8266 gateway.