### PR TITLE
Update cast in msg.set

### DIFF
--- a/examples/CO2Sensor/CO2Sensor.ino
+++ b/examples/CO2Sensor/CO2Sensor.ino
@@ -95,7 +95,7 @@ void loop()
 	long co2ppm = 2 * ((duration/1000) - 2);
 	//Serial.print(co2ppm);
 	if ((co2ppm != lastAIQ)&&(abs(co2ppm-lastAIQ)>=10)) {
-		send(msg.set((long)ceil(co2ppm)));
+		send(msg.set((int32_t)ceil(co2ppm)));
 		lastAIQ = ceil(co2ppm);
 	}
 

--- a/examples/DustSensorDSM/DustSensorDSM.ino
+++ b/examples/DustSensorDSM/DustSensorDSM.ino
@@ -95,7 +95,7 @@ void loop()
 	Serial.print("\n");
 
 	if ((concentrationPM25 != lastDUSTPM25)&&(concentrationPM25>0)) {
-		send(dustMsgPM25.set((long)ceil(concentrationPM25)));
+		send(dustMsgPM25.set((int32_t)ceil(concentrationPM25)));
 		lastDUSTPM25 = ceil(concentrationPM25);
 	}
 
@@ -110,7 +110,7 @@ void loop()
 	long ppmv=(concentrationPM10*0.0283168/100/1000) *  (0.08205*temp)/0.01;
 
 	if ((ceil(concentrationPM10) != lastDUSTPM10)&&((long)concentrationPM10>0)) {
-		send(dustMsgPM10.set((long)ppmv));
+		send(dustMsgPM10.set((int32_t)ppmv));
 		lastDUSTPM10 = ceil(concentrationPM10);
 	}
 

--- a/examples/SoilMoistSensor/SoilMoistSensor.ino
+++ b/examples/SoilMoistSensor/SoilMoistSensor.ino
@@ -138,7 +138,7 @@ void loop()
 	Serial.println ();
 
 	//send back the values
-	send(msg.set((long int)ceil(sensor1)));
+	send(msg.set((int32_t)ceil(sensor1)));
 	// delay until next measurement (msec)
 	sleep(SLEEP_TIME);
 }


### PR DESCRIPTION
A while ago, MySensors changed to use int32_t
instead of long int (and similar for other data
types). This change was not applied to all examples,
causing some examples to fail compilation for
ESP8266 with the following message:

call of overloaded 'set(long int)' is ambiguous

This update changes the casts to match the new style.
This fixes
https://github.com/mysensors/MySensors/issues/1129
Thanks to @henfri for reporting.