### PR TITLE
Add an error message about missing abstraction layer

### DIFF
--- a/MySensors.h
+++ b/MySensors.h
@@ -77,6 +77,8 @@
 #include "hal/architecture/Teensy3/MyHwTeensy3.cpp"
 #elif defined(__linux__)
 #include "hal/architecture/Linux/MyHwLinuxGeneric.cpp"
+#else
+#error Hardware abstraction not defined (unsupported platform)
 #endif
 
 // OTA Debug second part, depends on HAL


### PR DESCRIPTION
This would let the user of the library know the platform they're using is not supported instead of throwing out hundreds of errors.