### PR TITLE
Fix syntax error in MyGatewayTransportEthernet

### DIFF
--- a/core/MyGatewayTransportEthernet.cpp
+++ b/core/MyGatewayTransportEthernet.cpp
@@ -152,9 +152,9 @@ bool gatewayTransportInit(void)
 	WiFi.mode(WIFI_STA);
 #if defined(MY_HOSTNAME)
 #if defined(MY_GATEWAY_ESP8266)
-	WiFi.hostname(MY_HOSTNAME)
+	WiFi.hostname(MY_HOSTNAME);
 #elif defined(MY_GATEWAY_ESP32)
-	WiFi.setHostname(MY_HOSTNAME)
+	WiFi.setHostname(MY_HOSTNAME);
 #endif
 #endif
 #ifdef MY_IP_ADDRESS


### PR DESCRIPTION
Code doesn't compile very well if statements are missing
a semicolon at the end.

This error snuck in in
https://github.com/mysensors/MySensors/pull/1110