### PR TITLE
avoid data array overflow

### DIFF
--- a/hal/transport/RS485/MyTransportRS485.cpp
+++ b/hal/transport/RS485/MyTransportRS485.cpp
@@ -154,6 +154,12 @@ bool _serialProcess()
 				}
 				_recPhase = 1;
 				_recPos = 0;
+				
+					//Avoid _data[] overflow 
+				if (_recLen >= MY_RS485_MAX_MESSAGE_LENGTH){
+					_serialReset();
+					break;
+				}
 
 				//Check if we should process this message
 				//We reject the message if we are the sender


### PR DESCRIPTION
occurs through package collisions