### PR TITLE
AVR: Fix variable scope in SHA256 ASM

### DIFF
--- a/MySensors.h
+++ b/MySensors.h
@@ -60,8 +60,7 @@
 #elif defined(ARDUINO_ARCH_AVR)
 #include "drivers/AVR/DigitalWriteFast/digitalWriteFast.h"
 #include "hal/architecture/AVR/MyHwAVR.cpp"
-//#include "hal/crypto/AVR/MyCryptoAVR.cpp" // temporarily disabled, stack corruption possible
-#include "hal/crypto/generic/MyCryptoGeneric.cpp"
+#include "hal/crypto/AVR/MyCryptoAVR.cpp"
 #elif defined(ARDUINO_ARCH_SAMD)
 #include "drivers/extEEPROM/extEEPROM.cpp"
 #include "hal/architecture/SAMD/MyHwSAMD.cpp"

--- a/MySensors.h
+++ b/MySensors.h
@@ -60,7 +60,8 @@
 #elif defined(ARDUINO_ARCH_AVR)
 #include "drivers/AVR/DigitalWriteFast/digitalWriteFast.h"
 #include "hal/architecture/AVR/MyHwAVR.cpp"
-#include "hal/crypto/AVR/MyCryptoAVR.cpp"
+//#include "hal/crypto/AVR/MyCryptoAVR.cpp" // temporarily disabled, stack corruption possible
+#include "hal/crypto/generic/MyCryptoGeneric.cpp"
 #elif defined(ARDUINO_ARCH_SAMD)
 #include "drivers/extEEPROM/extEEPROM.cpp"
 #include "hal/architecture/SAMD/MyHwSAMD.cpp"

--- a/hal/architecture/AVR/MyHwAVR.h
+++ b/hal/architecture/AVR/MyHwAVR.h
@@ -33,7 +33,7 @@
 #include <Arduino.h>
 #endif
 
-#define MYSENSORS_SHA256_ASM_AVR	// use the ASM implementation for the sha256 code
+#define CRYPTO_LITTLE_ENDIAN
 
 #ifndef MY_SERIALDEVICE
 #define MY_SERIALDEVICE Serial

--- a/hal/crypto/AVR/MyCryptoAVR.h
+++ b/hal/crypto/AVR/MyCryptoAVR.h
@@ -48,6 +48,8 @@
 
 #include "hal/crypto/MyCryptoHAL.h"
 
+#define MY_CRYPTO_SHA256_ASM	//!< Switch to define correct variable scope for ASM SHA256 implementation
+
 #define SHA256_HASH_BITS  256	//!< Defines the size of a SHA-256 hash value in bits
 #define SHA256_HASH_BYTES (SHA256_HASH_BITS/8) //!< Defines the size of a SHA-256 hash value in bytes
 #define SHA256_BLOCK_BITS 512 //!< Defines the size of a SHA-256 input block in bits


### PR DESCRIPTION
- Fix: Stack corruption in AVR SHA256 ASM implementation due to non-static buffer definition