### PR TITLE
RF24: Fix RX issue regarding PA+LNA modules

### DIFF
--- a/drivers/RF24/RF24.cpp
+++ b/drivers/RF24/RF24.cpp
@@ -314,14 +314,13 @@ LOCAL bool RF24_sendMessage(const uint8_t recipient, const void *buf, const uint
 	                          RF24_CMD_WRITE_TX_PAYLOAD, (uint8_t *)buf, len, false );
 	// go, TX starts after ~10us, CE high also enables PA+LNA on supported HW
 	RF24_ce(HIGH);
-	delayMicroseconds(10); // datasheet: Pulse CE at least 10us
-	RF24_ce(LOW);
 	// timeout counter to detect HW issues
 	uint16_t timeout = 0xFFFF;
 	do {
 		RF24_status = RF24_getStatus();
 	} while  (!(RF24_status & ( _BV(RF24_MAX_RT) | _BV(RF24_TX_DS) )) && timeout--);
 	// timeout value after successful TX on 16Mhz AVR ~ 65500, i.e. msg is transmitted after ~36 loop cycles
+	RF24_ce(LOW);
 	// reset interrupts
 	RF24_setStatus(_BV(RF24_TX_DS) | _BV(RF24_MAX_RT) );
 	// Max retries exceeded


### PR DESCRIPTION
see https://forum.mysensors.org/topic/9642/nrf24-transmission-of-data-works-fine-but-constant-nack-s-produced

Comment by @Yveaux:
"The CE pulse is apparently used by amplified nrf24 radios to enable the lna receiver. This is not an issue when only sending, but for hardware acks the lna receiver should be enabled until the transmitted message has been acknowledged by the receiving node.
Shortening the CE pulse, and thereby disabling reception causes nacks to occur..."