### PR TITLE
Add lowlevel nRF24 functions

### DIFF
--- a/drivers/RF24/RF24.cpp
+++ b/drivers/RF24/RF24.cpp
@@ -419,6 +419,20 @@ LOCAL int16_t RF24_getSendingRSSI(void)
 	return static_cast<int16_t>(-29 - (8 * (RF24_getObserveTX() & 0xF)));
 }
 
+LOCAL void RF24_enableConstantCarrierWave(void)
+{
+	RF24_standBy();
+	delayMicroseconds(1500);
+	RF24_setRFSetup(RF24_RF_SETUP | _BV(RF24_CONT_WAVE) | _BV(RF24_PLL_LOCK) );
+	RF24_ce(HIGH);
+}
+
+LOCAL void RF24_disableConstantCarrierWave(void)
+{
+	RF24_ce(LOW);
+	RF24_setRFSetup(RF24_RF_SETUP);
+}
+
 #if defined(MY_RX_MESSAGE_BUFFER_FEATURE)
 LOCAL void RF24_irqHandler(void)
 {

--- a/drivers/RF24/RF24.h
+++ b/drivers/RF24/RF24.h
@@ -395,11 +395,11 @@ LOCAL int16_t RF24_getSendingRSSI(void);
 /**
 * @brief Generate a constant carrier wave at active channel & transmit power (for testing only).
 */
-LOCAL void RF24_enableConstantCarrierWave(void);
+LOCAL void RF24_enableConstantCarrierWave(void) __attribute__((unused));
 /**
 * @brief Stop generating a constant carrier wave (for testing only).
 */
-LOCAL void RF24_disableConstantCarrierWave(void);
+LOCAL void RF24_disableConstantCarrierWave(void) __attribute__((unused));
 
 
 #if defined(MY_RX_MESSAGE_BUFFER_FEATURE)

--- a/drivers/RF24/RF24.h
+++ b/drivers/RF24/RF24.h
@@ -146,7 +146,7 @@ extern HardwareSPI SPI;		//!<  SPI
 #define RF24_CONFIGURATION (uint8_t) (RF24_CRC_16 << 2)		//!< RF24_CONFIGURATION
 #endif
 #define RF24_FEATURE (uint8_t)( _BV(RF24_EN_DPL))	//!<  RF24_FEATURE
-#define RF24_RF_SETUP (uint8_t)( ((MY_RF24_DATARATE & 0b10 ) << 4) | ((MY_RF24_DATARATE & 0b01 ) << 3) | (MY_RF24_PA_LEVEL << 1) ) + 1 		//!< RF24_RF_SETUP, +1 for Si24R1 and LNA
+#define RF24_RF_SETUP (uint8_t)(( ((MY_RF24_DATARATE & 0b10 ) << 4) | ((MY_RF24_DATARATE & 0b01 ) << 3) | (MY_RF24_PA_LEVEL << 1) ) + 1) 		//!< RF24_RF_SETUP, +1 for Si24R1 and LNA
 
 // powerup delay
 #define RF24_POWERUP_DELAY_MS	(100u)		//!< Power up delay, allow VCC to settle, transport to become fully operational
@@ -392,6 +392,14 @@ LOCAL bool RF24_setTxPowerPercent(const uint8_t newPowerPercent);
 * @return Pseudo-RSSI based on ARC register
 */
 LOCAL int16_t RF24_getSendingRSSI(void);
+/**
+* @brief Generate a constant carrier wave at active channel & transmit power (for testing only).
+*/
+LOCAL void RF24_enableConstantCarrierWave(void);
+/**
+* @brief Stop generating a constant carrier wave (for testing only).
+*/
+LOCAL void RF24_disableConstantCarrierWave(void);
 
 
 #if defined(MY_RX_MESSAGE_BUFFER_FEATURE)

--- a/drivers/RF24/RF24registers.h
+++ b/drivers/RF24/RF24registers.h
@@ -129,6 +129,7 @@
 #define RF24_ARD			(4)
 #define RF24_ARC			(0)
 #define RF24_PLL_LOCK		(4)
+#define RF24_CONT_WAVE	(7)
 #define RF24_RF_DR			(3)
 #define RF24_RF_PWR			(6)
 #define RF24_RX_DR			(6)


### PR DESCRIPTION
For testing & diagnostics purposes only!
These functions are not used by the regular MySensors stack.