### PR TITLE
Inclusion mode: change pinmode to INPUT_PULLUP

### DIFF
--- a/core/MyInclusionMode.cpp
+++ b/core/MyInclusionMode.cpp
@@ -30,8 +30,7 @@ inline void inclusionInit()
 	_inclusionMode = false;
 #if defined(MY_INCLUSION_BUTTON_FEATURE)
 	// Setup digital in that triggers inclusion mode
-	hwPinMode(MY_INCLUSION_MODE_BUTTON_PIN, INPUT);
-	hwDigitalWrite(MY_INCLUSION_MODE_BUTTON_PIN, HIGH);
+	hwPinMode(MY_INCLUSION_MODE_BUTTON_PIN, INPUT_PULLUP);
 #endif
 #if defined (MY_INCLUSION_LED_PIN)
 	// Setup LED pin that indicates inclusion mode


### PR DESCRIPTION
- Fixes #1196

According to arduino references we should instead use INPUT_PULLUP as of Arduino 1.0.1
https://www.arduino.cc/en/Tutorial/DigitalPins