### PR TITLE
Fix not sending the messages to MQTT gateway with RF24

### DIFF
--- a/examples/MotionSensor/MotionSensor.ino
+++ b/examples/MotionSensor/MotionSensor.ino
@@ -69,6 +69,9 @@ void loop()
 
 	// Sleep until interrupt comes in on motion sensor. Send update every two minute.
 	sleep(digitalPinToInterrupt(DIGITAL_INPUT_SENSOR), CHANGE, SLEEP_TIME);
+	
+	// without this sleep; only the initial state is send to the gateway
+	delay(5);
 }
 
 


### PR DESCRIPTION
Based on a sugestion in the feedback; solves my problem that messages are not being sent to MQTT. The state changed were visible in the serial monitor. Strange

patrikr76 commented 6 months ago
So i was testing out the motionsensor sketch and it kept giving me "!TSF:MSG:SEND" after the initial 0 had been sent.

Finding no answers on here i tested loads of things until i tried a delay after the sleep command.
Running fine now with a 5msec delay.

Just thought i would share.