### PR TITLE
Rpi: flush log file

### DIFF
--- a/hal/architecture/Linux/drivers/core/log.c
+++ b/hal/architecture/Linux/drivers/core/log.c
@@ -140,6 +140,7 @@ void vlog(int level, const char *fmt, va_list args)
 		if (_log_file_fp != NULL) {
 			fprintf(_log_file_fp, "%s %-5s ", date, _log_level_names[level]);
 			vfprintf(_log_file_fp, fmt, args);
+			fflush(_log_file_fp);
 		}
 
 		if (!_log_quiet) {


### PR DESCRIPTION
The log file was no flushed, which meant that the lines logged
would not be visible in the file until (much) later, often
not until the gateway process exited.

By flushing the file, log information becomes available immediately.