### PR TITLE
Enable heartbeat for GW-only mode

### DIFF
--- a/core/MySensorsCore.cpp
+++ b/core/MySensorsCore.cpp
@@ -346,6 +346,10 @@ bool sendHeartbeat(const bool ack)
 	const uint32_t heartbeat = transportGetHeartbeat();
 	return _sendRoute(build(_msgTmp, GATEWAY_ADDRESS, NODE_SENSOR_ID, C_INTERNAL, I_HEARTBEAT_RESPONSE,
 	                        ack).set(heartbeat));
+#elif defined(MY_GATEWAY_FEATURE)
+	const uint32_t heartbeat = hwMillis();
+	return _sendRoute(build(_msgTmp, GATEWAY_ADDRESS, NODE_SENSOR_ID, C_INTERNAL, I_HEARTBEAT_RESPONSE,
+	                        ack).set(heartbeat));
 #else
 	(void)ack;
 	return false;


### PR DESCRIPTION
- Add heartbeat functionality for GW-only mode w/o defined transport network
see here: https://forum.mysensors.org/topic/10314/heartbeat-gateway