### PR TITLE
Added getSleepRemaining to core

### DIFF
--- a/core/MySensorsCore.cpp
+++ b/core/MySensorsCore.cpp
@@ -753,6 +753,10 @@ int8_t smartSleep(const uint8_t interrupt1, const uint8_t mode1, const uint8_t i
 	return _sleep(sleepingMS, true, interrupt1, mode1, interrupt2, mode2);
 }
 
+uint32_t getSleepRemaining(void)
+{
+	return hwGetSleepRemaining();
+}
 
 
 void _nodeLock(const char *str)

--- a/core/MySensorsCore.h
+++ b/core/MySensorsCore.h
@@ -364,6 +364,13 @@ int8_t _sleep(const uint32_t sleepingMS, const bool smartSleep = false,
               const uint8_t interrupt1 = INTERRUPT_NOT_DEFINED, const uint8_t mode1 = MODE_NOT_DEFINED,
               const uint8_t interrupt2 = INTERRUPT_NOT_DEFINED, const uint8_t mode2 = MODE_NOT_DEFINED);
 
+/**
+ * Return the sleep time remaining after waking up from sleep.
+ * Depending on the CPU architecture, the remaining time can be seconds off (e.g. upto roughly 8 seconds on AVR).
+ * @return Time remaining, in ms, when wake from sleep by an interrupt, 0 by timer (@ref MY_WAKE_UP_BY_TIMER), undefined otherwise.
+*/
+uint32_t getSleepRemaining(void);
+
 
 // **** private functions ********
 

--- a/hal/architecture/AVR/MyHwAVR.h
+++ b/hal/architecture/AVR/MyHwAVR.h
@@ -77,7 +77,7 @@ bool hwInit(void);
 #define hwWriteConfigBlock(__buf, __pos, __length) eeprom_update_block((const void *)__buf, (void *)__pos, (uint32_t)__length)
 
 inline void hwRandomNumberInit(void);
-void hwInternalSleep(uint32_t ms);
+uint32_t hwInternalSleep(uint32_t ms);
 
 #if defined(MY_SOFTSPI)
 SoftSPI<MY_SOFT_SPI_MISO_PIN, MY_SOFT_SPI_MOSI_PIN, MY_SOFT_SPI_SCK_PIN, 0> hwSPI; //!< hwSPI

--- a/hal/architecture/ESP32/MyHwESP32.h
+++ b/hal/architecture/ESP32/MyHwESP32.h
@@ -74,6 +74,7 @@
 #define hwMillis() millis()
 #define hwMicros() micros()
 #define hwRandomNumberInit() randomSeed(esp_random())
+#define hwGetSleepRemaining() (0ul)
 
 bool hwInit(void);
 void hwReadConfigBlock(void *buf, void *addr, size_t length);

--- a/hal/architecture/ESP8266/MyHwESP8266.h
+++ b/hal/architecture/ESP8266/MyHwESP8266.h
@@ -49,6 +49,7 @@
 #define hwMillis() millis()
 // The use of randomSeed switch to pseudo random number. Keep hwRandomNumberInit empty
 #define hwRandomNumberInit()
+#define hwGetSleepRemaining() (0ul)
 
 bool hwInit(void);
 void hwReadConfigBlock(void *buf, void *addr, size_t length);

--- a/hal/architecture/Linux/MyHwLinuxGeneric.h
+++ b/hal/architecture/Linux/MyHwLinuxGeneric.h
@@ -54,6 +54,7 @@ StdInOutStream Serial = StdInOutStream();
 // Define these as macros (do nothing)
 #define hwWatchdogReset()
 #define hwReboot()
+#define hwGetSleepRemaining() (0ul)
 
 inline void hwDigitalWrite(uint8_t, uint8_t);
 inline int hwDigitalRead(uint8_t);

--- a/hal/architecture/NRF5/MyHwNRF5.h
+++ b/hal/architecture/NRF5/MyHwNRF5.h
@@ -114,6 +114,8 @@
 #define hwDigitalRead(__pin) digitalRead(__pin)
 #define hwPinMode(__pin, __value) nrf5_pinMode(__pin, __value)
 #define hwMillis() millis()
+// TODO: Can nrf5 determine time slept?
+#define hwGetSleepRemaining() (0ul)
 
 bool hwInit(void);
 void hwWatchdogReset(void);

--- a/hal/architecture/SAMD/MyHwSAMD.h
+++ b/hal/architecture/SAMD/MyHwSAMD.h
@@ -63,6 +63,7 @@ extEEPROM eep(MY_EXT_EEPROM_SIZE, 1, MY_EXT_EEPROM_PAGE_SIZE,
 #define hwPinMode(__pin, __value) pinMode(__pin, __value)
 #define hwMillis() millis()
 #define hwRandomNumberInit() randomSeed(analogRead(MY_SIGNING_SOFT_RANDOMSEED_PIN))
+#define hwGetSleepRemaining() (0ul)
 
 bool hwInit(void);
 void hwWatchdogReset(void);

--- a/hal/architecture/STM32F1/MyHwSTM32F1.h
+++ b/hal/architecture/STM32F1/MyHwSTM32F1.h
@@ -69,6 +69,7 @@
 #define hwWatchdogReset() iwdg_feed()
 #define hwReboot() nvic_sys_reset()
 #define hwMillis() millis()
+#define hwGetSleepRemaining() (0ul)
 
 extern void serialEventRun(void) __attribute__((weak));
 bool hwInit(void);

--- a/hal/architecture/Teensy3/MyHwTeensy3.h
+++ b/hal/architecture/Teensy3/MyHwTeensy3.h
@@ -62,6 +62,7 @@
 #define hwDigitalRead(__pin) digitalReadFast(__pin)
 #define hwPinMode(__pin, __value) pinMode(__pin, __value)
 #define hwMillis() millis()
+#define hwGetSleepRemaining() (0ul)
 
 void hwRandomNumberInit(void);
 bool hwInit(void);


### PR DESCRIPTION
Add support to retrieve remaining sleep time when wake up by interrupt.
Only implemented for AVR; other architectures except NRF5 don't sleep. Unsure if NRF5 can retrieve remaining sleep time.
As AVR sleeps using watchdog in 8192ms or smaller steps, the reported remainign time can be up to roughly 8 seconds off.
