### PR TITLE
MySensorsCore: new sendAsIs() function

### DIFF
--- a/core/MySensorsCore.cpp
+++ b/core/MySensorsCore.cpp
@@ -322,8 +322,13 @@ bool _sendRoute(MyMessage &message)
 
 bool send(MyMessage &message, const bool enableAck)
 {
-	message.sender = getNodeId();
 	mSetCommand(message, C_SET);
+	return sendAsIs(message, enableAck)
+}
+
+bool sendAsIs(MyMessage &message, const bool enableAck)
+{
+	message.sender = getNodeId();
 	mSetRequestAck(message, enableAck);
 
 #if defined(MY_REGISTRATION_FEATURE) && !defined(MY_GATEWAY_FEATURE)

--- a/core/MySensorsCore.h
+++ b/core/MySensorsCore.h
@@ -162,6 +162,7 @@ bool sendSketchInfo(const __FlashStringHelper *name, const __FlashStringHelper *
 * @return true Returns true if message reached the first stop on its way to destination.
 */
 bool send(MyMessage &msg, const bool ack = false);
+bool sendAsIs(MyMessage &msg, const bool ack = false);
 
 /**
  * Send this nodes battery level to gateway.


### PR DESCRIPTION
Do not force a C_SET command, letting the client use a C_INTERNAL one,
e.g. to send the library version to the controller.