### PR TITLE
Rename RadioSettingGrpPub to TransportSettingGrpPub

### DIFF
--- a/MyConfig.h
+++ b/MyConfig.h
@@ -192,16 +192,16 @@
 
 
 /**
- * @defgroup RadioSettingGrpPub Radio selection
+ * @defgroup TransportSettingGrpPub Transport selection
  * @ingroup MyConfigGrp
- * @brief These options control what radio type to use and various radio specific customisations.
+ * @brief These options control what transport type to use and various transport specific customisations.
  * @{
  */
 
 
 /**
  * @defgroup RS485SettingGrpPub RS485
- * @ingroup RadioSettingGrpPub
+ * @ingroup TransportSettingGrpPub
  * @brief These options are specific to the RS485 wired transport.
  * @{
  */
@@ -254,7 +254,7 @@
 
 /**
  * @defgroup RF24SettingGrpPub RF24
- * @ingroup RadioSettingGrpPub
+ * @ingroup TransportSettingGrpPub
  * @brief These options are specific to the RF24 family of wireless transport modules.
  *
  * The following chips are supported by this driver:
@@ -441,7 +441,7 @@
 
 /**
  * @defgroup NRF5SettingGrpPub nRF5
- * @ingroup RadioSettingGrpPub
+ * @ingroup TransportSettingGrpPub
  * @brief These options are specific to the nRF5 (with Enhanced ShockBurst) family of wireless
  * transport modules.
  *
@@ -572,7 +572,7 @@
 
 /**
  * @defgroup RFM69SettingGrpPub RFM69
- * @ingroup RadioSettingGrpPub
+ * @ingroup TransportSettingGrpPub
  * @brief These options are specific to the %RFM69 family of wireless transport modules.
  *
  * The following chips are supported by this driver:
@@ -793,7 +793,7 @@
 
 /**
  * @defgroup RFM95SettingGrpPub RFM95
- * @ingroup RadioSettingGrpPub
+ * @ingroup TransportSettingGrpPub
  * @brief These options are specific to the %RFM95 family of wireless transport modules.
  *
  * The following chips are supported by this driver:
@@ -955,7 +955,7 @@
 
 /**
  * @defgroup SoftSpiSettingGrpPub Soft SPI
- * @ingroup RadioSettingGrpPub
+ * @ingroup TransportSettingGrpPub
  * @brief These options are specific the soft SPI driver for certain radio transport drivers.
  *
  * The following transport drivers supported by this driver:
@@ -997,7 +997,7 @@
 #endif
 /** @}*/ // End of SoftSpiSettingGrpPub group
 
-/** @}*/ // End of RadioSettingGrpPub group
+/** @}*/ // End of TransportSettingGrpPub group
 
 /**
  * @defgroup RoutingNodeSettingGrpPub Routing and node


### PR DESCRIPTION
https://www.mysensors.org/apidocs/group__RadioSettingGrpPub.html
had the headline "Radio selection". In MySensors lingo, we
probably mean "Transport selection", especially since RS485 is
included but does not use radio.

By renaming the group and the text, it might become easier for
users to understand which different transports are supported
by MySensors.

This fixes https://github.com/mysensors/MySensors/issues/1272