### PR TITLE
Add CXXFLAGS to configure output

### DIFF
--- a/configure
+++ b/configure
@@ -666,10 +666,11 @@ else
     printf "  ${OK} Encryption: Disabled.\n"
 fi
 
-printf "  ${OK} CPPFLAGS: $CPPFLAGS\n"
-
 LDFLAGS="-pthread $LDFLAGS"
 CPPFLAGS="$CPUFLAGS $CPPFLAGS"
+
+printf "  ${OK} CPPFLAGS: $CPPFLAGS\n"
+printf "  ${OK} CXXFLAGS: $CXXFLAGS\n"
 
 printf "${SECTION} Detecting init system.\n"
 if [ "${NO_INIT}" ];  then


### PR DESCRIPTION
Printing the CXXFLAGS might help people notice when they are
not including all parameters on one line.

Printing of CPPFLAGS was added in cd4acb2b8.