### PR TITLE
Move noACK control to transportSendWrite()

### DIFF
--- a/core/MyTransport.cpp
+++ b/core/MyTransport.cpp
@@ -978,17 +978,15 @@ bool transportSendWrite(const uint8_t to, MyMessage &message)
 	// msg length changes if signed
 	const uint8_t totalMsgLength = HEADER_SIZE + ( message.getSigned() ? MAX_PAYLOAD_SIZE :
 	                               message.getLength() );
-
+	const bool noACK = _transportConfig.passiveMode || (to == BROADCAST_ADDRESS);
 	// send
 	setIndication(INDICATION_TX);
-	bool result = transportHALSend(to, &message, totalMsgLength,
-	                               _transportConfig.passiveMode);
-	// broadcasting (workaround counterfeits)
-	result |= (to == BROADCAST_ADDRESS);
+	const bool result = transportHALSend(to, &message, totalMsgLength,
+	                                     noACK);
 
 	TRANSPORT_DEBUG(PSTR("%sTSF:MSG:SEND,%" PRIu8 "-%" PRIu8 "-%" PRIu8 "-%" PRIu8 ",s=%" PRIu8 ",c=%"
 	                     PRIu8 ",t=%" PRIu8 ",pt=%" PRIu8 ",l=%" PRIu8 ",sg=%" PRIu8 ",ft=%" PRIu8 ",st=%s:%s\n"),
-	                (_transportConfig.passiveMode ? "?" : result ? "" : "!"), message.getSender(), message.getLast(),
+	                (noACK ? "?" : result ? "" : "!"), message.getSender(), message.getLast(),
 	                to,
 	                message.getDestination(),
 	                message.getSensor(),

--- a/hal/transport/RFM69/MyTransportRFM69.cpp
+++ b/hal/transport/RFM69/MyTransportRFM69.cpp
@@ -59,11 +59,7 @@ uint8_t transportGetAddress(void)
 
 bool transportSend(const uint8_t to, const void *data, uint8_t len, const bool noACK)
 {
-	if (noACK) {
-		(void)RFM69_sendWithRetry(to, data, len, 0, 0);
-		return true;
-	}
-	return RFM69_sendWithRetry(to, data, len);
+	return RFM69_sendWithRetry(to, data, len, noACK);
 }
 
 bool transportDataAvailable(void)

--- a/hal/transport/RFM69/driver/new/RFM69_new.h
+++ b/hal/transport/RFM69/driver/new/RFM69_new.h
@@ -466,13 +466,12 @@ LOCAL void RFM69_sendACK(const uint8_t recipient, const rfm69_sequenceNumber_t s
 * @param recipient
 * @param buffer
 * @param bufferSize
-* @param retries
-* @param retryWaitTimeMS
+* @param noACK
 * @return True if packet successfully sent
 */
 LOCAL bool RFM69_sendWithRetry(const uint8_t recipient, const void *buffer,
                                const uint8_t bufferSize,
-                               const uint8_t retries = RFM69_RETRIES, const uint32_t retryWaitTimeMS = RFM69_RETRY_TIMEOUT_MS);
+                               const bool noACK);
 
 /**
 * @brief RFM69_setRadioMode

--- a/hal/transport/RFM95/MyTransportRFM95.cpp
+++ b/hal/transport/RFM95/MyTransportRFM95.cpp
@@ -44,11 +44,7 @@ uint8_t transportGetAddress(void)
 
 bool transportSend(const uint8_t to, const void *data, const uint8_t len, const bool noACK)
 {
-	if (noACK) {
-		(void)RFM95_sendWithRetry(to, data, len, 0, 0);
-		return true;
-	}
-	return RFM95_sendWithRetry(to, data, len);
+	return RFM95_sendWithRetry(to, data, len, noACK);
 }
 
 bool transportDataAvailable(void)

--- a/hal/transport/RFM95/driver/RFM95.cpp
+++ b/hal/transport/RFM95/driver/RFM95.cpp
@@ -539,24 +539,24 @@ LOCAL bool RFM95_executeATC(const rfm95_RSSI_t currentRSSI, const rfm95_RSSI_t t
 }
 
 LOCAL bool RFM95_sendWithRetry(const uint8_t recipient, const void *buffer,
-                               const uint8_t bufferSize, const uint8_t retries, const uint32_t retryWaitTime)
+                               const uint8_t bufferSize, const bool noACK)
 {
-	for (uint8_t retry = 0; retry <= retries; retry++) {
+	for (uint8_t retry = 0; retry < RFM95_RETRIES; retry++) {
 		RFM95_DEBUG(PSTR("RFM95:SWR:SEND,TO=%" PRIu8 ",SEQ=%" PRIu16 ",RETRY=%" PRIu8 "\n"), recipient,
 		            RFM95.txSequenceNumber,
 		            retry);
 		rfm95_controlFlags_t flags = 0u;
-		RFM95_setACKRequested(flags, (recipient != RFM95_BROADCAST_ADDRESS));
+		RFM95_setACKRequested(flags, noACK);
 		// send packet
 		if (!RFM95_send(recipient, (uint8_t *)buffer, bufferSize, flags, !retry)) {
 			return false;
 		}
 		(void)RFM95_setRadioMode(RFM95_RADIO_MODE_RX);
-		if (recipient == RFM95_BROADCAST_ADDRESS) {
+		if (noACK) {
 			return true;
 		}
 		const uint32_t enterMS = hwMillis();
-		while (hwMillis() - enterMS < retryWaitTime && !RFM95.dataReceived) {
+		while (hwMillis() - enterMS < RFM95_RETRY_TIMEOUT_MS && !RFM95.dataReceived) {
 			RFM95_handler();
 			if (RFM95.ackReceived) {
 				const uint8_t sender = RFM95.currentPacket.header.sender;

--- a/hal/transport/RFM95/driver/RFM95.h
+++ b/hal/transport/RFM95/driver/RFM95.h
@@ -402,13 +402,11 @@ LOCAL void RFM95_sendACK(const uint8_t recipient, const rfm95_sequenceNumber_t s
 * @param recipient
 * @param buffer
 * @param bufferSize
-* @param retries
-* @param retryWaitTime
+* @param noACK
 * @return True if packet successfully sent
 */
 LOCAL bool RFM95_sendWithRetry(const uint8_t recipient, const void *buffer,
-                               const uint8_t bufferSize, const uint8_t retries = RFM95_RETRIES,
-                               const uint32_t retryWaitTime = RFM95_RETRY_TIMEOUT_MS);
+                               const uint8_t bufferSize, const bool noACK);
 /**
 * @brief Wait until no channel activity detected
 * @return True if no channel activity detected, False if timeout occured


### PR DESCRIPTION
- Handle noACK flags globally: BC messages & passive mode
- Follow up of #1316 