### PR TITLE
Exclude items from the Arduino library package

### DIFF
--- a/library.json
+++ b/library.json
@@ -14,6 +14,12 @@
     "exclude": [
       "tests",
       "Documentation",
+      ".mystools",
+      "projects",
+      "examples_linux",
+      "initscripts",
+      "configure",
+      ".ci",
       "Doxyfile"
     ]
   }


### PR DESCRIPTION
.mystools causes the stupid warning "Spurious folder" in the Arduino IDE, confusing our users
projects (Sublime-specific files)
examples_linux (only applicable for the rpi gw)
initscripts  (only applicable for the rpi gw)
configure   (only applicable for the rpi gw)
.ci (files for Jenkins)

None of these files are useful in the Arduino IDE context (and probably not for PlatformIO either, which uses the same library file).

People who do have a use for these files will probably check out the code from github instead (or at least download the zip from github), resulting in a full download with all files.