### PR TITLE
MyTransport update

### DIFF
--- a/core/MyTransport.cpp
+++ b/core/MyTransport.cpp
@@ -505,7 +505,6 @@ bool transportAssignNodeID(const uint8_t newNodeId)
 	} else {
 		TRANSPORT_DEBUG(PSTR("!TSF:SID:FAIL,ID=%" PRIu8 "\n"),newNodeId);	// ID is invalid, cannot assign ID
 		setIndication(INDICATION_ERR_NET_FULL);
-		_transportConfig.nodeId = AUTO;
 		return false;
 	}
 }
@@ -1092,6 +1091,7 @@ void transportTogglePassiveMode(const bool OnOff)
 
 int16_t transportGetSignalReport(const signalReport_t signalReport)
 {
+#if defined(MY_SIGNAL_REPORT_ENABLED)
 	int16_t result;
 	switch (signalReport) {
 	case SR_RX_RSSI:
@@ -1120,10 +1120,15 @@ int16_t transportGetSignalReport(const signalReport_t signalReport)
 		break;
 	}
 	return result;
+#else
+	(void)signalReport;
+	return 0;
+#endif
 }
 
 int16_t transportSignalReport(const char command)
 {
+#if defined(MY_SIGNAL_REPORT_ENABLED)
 	signalReport_t reportCommand;
 	switch (command) {
 	case 'S':
@@ -1161,4 +1166,8 @@ int16_t transportSignalReport(const char command)
 	const uint16_t result = transportGetSignalReport(reportCommand);
 	TRANSPORT_DEBUG(PSTR("TSF:SIR:CMD=%" PRIu8 ",VAL=%" PRIu16 "\n"), reportCommand, result);
 	return result;
+#else
+	(void)command;
+	return 0;
+#endif
 }

--- a/core/MyTransport.h
+++ b/core/MyTransport.h
@@ -307,7 +307,9 @@ typedef struct {
 	uint8_t failureCounter : 3;							//!< counter for TSM failures (max 7)
 	bool msgReceived : 1;										//!< flag message received
 	uint8_t pingResponse;										//!< stores I_PONG hops
+#if defined(MY_SIGNAL_REPORT_ENABLED)
 	transportRSSI_t uplinkQualityRSSI;			//!< Uplink quality, internal RSSI representation
+#endif
 } transportSM_t;
 
 /**
@@ -545,6 +547,7 @@ void transportDisable(void);
 * @brief Reinitialise transport. Put transport to standby - If xxx_POWER_PIN set, power up and go to standby
 */
 void transportReInitialise(void);
+
 /**
 * @brief Get transport signal report
 * @param command:
@@ -557,14 +560,14 @@ void transportReInitialise(void);
 * U = Uplink quality (via ACK from parent node), avg. RSSI
 * @return Signal report (if report is not available, INVALID_RSSI, INVALID_SNR, INVALID_PERCENT, or INVALID_LEVEL is sent instead)
 */
-int16_t transportSignalReport(const char command);
+int16_t transportSignalReport(const char command) __attribute__((unused));
 
 /**
 * @brief Get transport signal report
 * @param signalReport
 * @return report
 */
-int16_t transportGetSignalReport(const signalReport_t signalReport);
+int16_t transportGetSignalReport(const signalReport_t signalReport) __attribute__((unused));
 
 #endif // MyTransport_h
 /** @}*/

--- a/core/Version.h
+++ b/core/Version.h
@@ -50,7 +50,7 @@
 #define MYSENSORS_LIBRARY_VERSION_MINOR							3							//!< Minor release version
 #define MYSENSORS_LIBRARY_VERSION_PATCH							2							//!< Patch version
 #define MYSENSORS_LIBRARY_VERSION_PRERELEASE					"beta"						//!< Pre-release suffix, i.e. alpha, beta, rc.1, etc
-#define MYSENSORS_LIBRARY_VERSION_PRERELEASE_NUMBER				0x06						//!< incremental counter, starting at 0x00. 0xFF for final release
+#define MYSENSORS_LIBRARY_VERSION_PRERELEASE_NUMBER				0x07						//!< incremental counter, starting at 0x00. 0xFF for final release
 
 
 #if (MYSENSORS_LIBRARY_VERSION_PRERELEASE_NUMBER != 0xFF)


### PR DESCRIPTION
- Fix: do not set nodeID to AUTO if invalid I_ID_RESPONSE received
- Save 2 bytes of RAM: remove transportSM variable (uplinkQualityRSSI) if unused
- Bump pre-release version to 7