### PR TITLE
We fix an infinite loop if Power-down mode enabled

### DIFF
--- a/drivers/SPIFlash/SPIFlash.cpp
+++ b/drivers/SPIFlash/SPIFlash.cpp
@@ -199,7 +199,7 @@ void SPIFlash::command(uint8_t cmd, bool isWrite)
 	//  that is because some chips can take several seconds to carry out a chip erase or other similar multi block or entire-chip operations
 	//  a recommended alternative to such situations where chip can be or not be present is to add a 10k or similar weak pulldown on the
 	//  open drain MISO input which can read noise/static and hence return a non 0 status byte, causing the while() to hang when a flash chip is not present
-	while(busy());
+	if (cmd != SPIFLASH_WAKE) while(busy()); // otherwise, if the SPI flash after the bootloader is in Power-down mode, we have an infinite loop and it doesn’t come to sending the SPIFLASH_WAKE command
 	select();
 	SPI.transfer(cmd);
 }


### PR DESCRIPTION
If the bootloader puts the SPI flash into Power-down mode, then thanks to busy () we have an infinite loop and it doesn’t get to sending the SPIFLASH_WAKE command.