### PR TITLE
Fix potential buffer overflow

### DIFF
--- a/hal/architecture/Linux/drivers/core/GPIO.cpp
+++ b/hal/architecture/Linux/drivers/core/GPIO.cpp
@@ -50,7 +50,7 @@ GPIOClass::GPIOClass()
 		}
 
 		if (strncmp("gpiochip", de->d_name, 8) == 0) {
-			sprintf(file, "/sys/class/gpio/%s/base", de->d_name);
+			snprintf(file, sizeof(file), "/sys/class/gpio/%s/base", de->d_name);
 			f = fopen(file, "r");
 			int base;
 			if (fscanf(f, "%d", &base) == EOF) {
@@ -59,7 +59,7 @@ GPIOClass::GPIOClass()
 			}
 			fclose(f);
 
-			sprintf(file, "/sys/class/gpio/%s/ngpio", de->d_name);
+			snprintf(file, sizeof(file), "/sys/class/gpio/%s/ngpio", de->d_name);
 			f = fopen(file, "r");
 			int ngpio;
 			if (fscanf(f, "%d", &ngpio) == EOF) {


### PR DESCRIPTION
Use snprintf instead of sprintf to avoid a potential buffer overflow, as noted by the compiler:

hal/architecture/Linux/drivers/core/GPIO.cpp: In constructor ‘GPIOClass::GPIOClass()’:
hal/architecture/Linux/drivers/core/GPIO.cpp:53:18: warning: ‘%s’ directive writing up to 255 bytes into a region of size 48 [-Wformat-overflow=]
    sprintf(file, "/sys/class/gpio/%s/base", de->d_name);
                  ^~~~~~~~~~~~~~~~~~~~~~~~~
hal/architecture/Linux/drivers/core/GPIO.cpp:53:11: note: ‘sprintf’ output between 22 and 277 bytes into a destination of size 64
    sprintf(file, "/sys/class/gpio/%s/base", de->d_name);
    ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
hal/architecture/Linux/drivers/core/GPIO.cpp:62:18: warning: ‘%s’ directive writing up to 255 bytes into a region of size 48 [-Wformat-overflow=]
    sprintf(file, "/sys/class/gpio/%s/ngpio", de->d_name);
                  ^~~~~~~~~~~~~~~~~~~~~~~~~~
hal/architecture/Linux/drivers/core/GPIO.cpp:62:11: note: ‘sprintf’ output between 23 and 278 bytes into a destination of size 64
    sprintf(file, "/sys/class/gpio/%s/ngpio", de->d_name);
    ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~