### PR TITLE
Fix double free

### DIFF
--- a/hal/architecture/Linux/drivers/core/SoftEeprom.cpp
+++ b/hal/architecture/Linux/drivers/core/SoftEeprom.cpp
@@ -98,9 +98,11 @@ void SoftEeprom::destroy()
 {
 	if (_values) {
 		delete[] _values;
+		_values = NULL;
 	}
 	if (_fileName) {
 		free(_fileName);
+		_fileName = NULL;
 	}
 	_length = 0;
 }


### PR DESCRIPTION
_fileName and _values have to be re-set to NULL, otherwise a double-free might occur.

First destroy() is called when the eeprom filesize does not match, the second destroy() is called from the dtor of SoftEeprom on exit:

Nov 11 17:00:01 INFO  Starting gateway...
Nov 11 17:00:01 INFO  Protocol version - 2.3.2-beta
Nov 11 17:00:01 ERROR EEPROM file /etc/mysensors.eeprom is not the correct size of 1024.  Please remove the file and a new one will be created.
double free or corruption (!prev)

Program received signal SIGABRT, Aborted.
__GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:51
51	../sysdeps/unix/sysv/linux/raise.c: Datei oder Verzeichnis nicht gefunden.
(gdb) bt
#0  __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:51
#1  0x76c6ed2c in __GI_abort () at abort.c:79
#2  0x76ca8cec in __libc_message (action=action@entry=do_abort, fmt=<optimized out>) at ../sysdeps/posix/libc_fatal.c:181
#3  0x76caf550 in malloc_printerr (str=<optimized out>) at malloc.c:5350
#4  0x76cb15ac in _int_free (av=0x76d8a7c4 <main_arena>, p=0x485d8, have_lock=<optimized out>) at malloc.c:4281
#5  0x0001931c in SoftEeprom::destroy (this=0x406f4 <eeprom>) at hal/architecture/Linux/drivers/core/SoftEeprom.cpp:100
#6  SoftEeprom::~SoftEeprom (this=0x406f4 <eeprom>, __in_chrg=<optimized out>) at hal/architecture/Linux/drivers/core/SoftEeprom.cpp:46
#7  0x76c70424 in __run_exit_handlers (status=status@entry=1, listp=<optimized out>, run_list_atexit=run_list_atexit@entry=true, run_dtors=run_dtors@entry=true) at exit.c:108
#8  0x76c7054c in __GI_exit (status=status@entry=1) at exit.c:139
#9  0x00026840 in hwInit () at ./hal/architecture/Linux/MyHwLinuxGeneric.cpp:38
#10 _begin () at ./core/MySensorsCore.cpp:116
#11 0x00012f08 in main (argc=1, argv=0xc) at ./hal/architecture/Linux/MyMainLinuxGeneric.cpp:447

I would suggest changing the _fileName to a std::string and _values to a std::vector<uint8_t>. I would make the change, if you're ok with it?